### PR TITLE
Feature/converter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.Packaging
+import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 import java.io.FileInputStream
 import java.util.Properties
@@ -178,6 +179,7 @@ dependencies {
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.mockk.agent)
     testImplementation(libs.json)
+    testImplementation("androidx.arch.core:core-testing:2.1.0")
 
     // Test UI
     androidTestImplementation(libs.androidx.junit)
@@ -197,13 +199,19 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     // CameraX
-    // CameraX
     implementation("androidx.camera:camera-core:1.1.0")
     implementation("androidx.camera:camera-camera2:1.1.0")
     implementation("androidx.camera:camera-lifecycle:1.1.0")
     implementation("androidx.camera:camera-view:1.0.0-alpha30")
     implementation("androidx.camera:camera-video:1.1.0")
-    implementation ("com.google.guava:guava:31.1-android")
+    implementation("com.google.guava:guava:31.1-android")
+
+    // Apache Poi
+    implementation("org.apache.poi:poi-ooxml:5.2.3") {
+        exclude(group = "org.apache.poi", module = "poi-ooxml-lite")
+    }
+    implementation("org.apache.poi:poi-ooxml-schemas:4.1.2")
+    implementation("org.apache.xmlbeans:xmlbeans:5.1.1")
 
     // Material 3
     implementation("androidx.compose.material3:material3:1.1.0")

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
@@ -1,0 +1,195 @@
+package com.github.se.eduverse.ui.converter
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasType
+import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Screen
+import com.github.se.eduverse.viewmodel.PdfConverterViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.any
+import java.util.concurrent.CompletableFuture.allOf
+
+@RunWith(AndroidJUnit4::class)
+class PdfConverterScreenTest {
+
+    private lateinit var mockNavigationActions: NavigationActions
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        Intents.init()
+
+        mockNavigationActions = mock(NavigationActions::class.java)
+
+        `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.PDF_CONVERTER)
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun topNavigationBarIsCorrectlyDisplayed() {
+        composeTestRule.setContent {
+            PdfConverterScreen(mockNavigationActions)
+        }
+        composeTestRule.onNodeWithTag("topNavigationBar").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("screenTitle").assertTextEquals("PDF Converter")
+        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("goBackButton").performClick()
+        verify(mockNavigationActions).goBack()
+    }
+
+    @Test
+    fun allPdfConverterOptionsAreCorrectlyDisplayed() {
+        composeTestRule.setContent {
+            PdfConverterScreen(mockNavigationActions)
+        }
+        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertTextEquals("Text to PDF")
+        composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertTextEquals("Image to PDF")
+        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertHasClickAction()
+        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertTextEquals("Scanner tool")
+        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertHasClickAction()
+        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertTextEquals("Summarize file")
+        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertHasClickAction()
+        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertTextEquals("Extract text")
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun clickingTextToPdfOption_launchesFilePicker() {
+        composeTestRule.setContent {
+            PdfConverterScreen(mockNavigationActions)
+        }
+
+        // Set up the activity result for the intent
+        // Simulate the file picker intent
+        val expectedUri = Uri.parse("content://test-document-uri")
+        val resultIntent = Intent().apply { data = expectedUri }
+        Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun clickingImageToPdfOption_launchesFilePicker() {
+        composeTestRule.setContent {
+            PdfConverterScreen(mockNavigationActions)
+        }
+        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    }
+
+    @Test
+    fun testPdfNameInputDialog() {
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = {})
+        }
+
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("pdfNameInput").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("test.pdf")
+        composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("PDF File Name")
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsEnabled()
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertTextEquals("Create PDF")
+        composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertTextEquals("Cancel")
+    }
+
+    @Test
+    fun testPdfNameInputDialog_confirmButtonDisabledWithEmptyFileName() {
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = {})
+        }
+
+        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsNotEnabled()
+    }
+
+    @Test
+    fun testPdfNameInputDialog_confirm() {
+        var confirmedFileName = ""
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
+        }
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+        assert(confirmedFileName == "test.pdf")
+    }
+
+    @Test
+    fun testPdfNameInputDialog_confirmCallsOnConfirm() {
+        var confirmedFileName = ""
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = { confirmedFileName = it })
+        }
+        composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+        assert(confirmedFileName == "test.pdf")
+    }
+
+    @Test
+    fun testPdfNameInputDialog_confirmWithoutInputKeepsDefaultFileName() {
+        var confirmedFileName = ""
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
+        }
+
+        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+        assert(confirmedFileName == "test.pdf")
+    }
+
+    @Test
+    fun testPdfNameInputDialog_callsOnDismissWhenCancelPressed() {
+        var dismissed = false
+        composeTestRule.setContent {
+            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = { dismissed = true }, onConfirm = {})
+        }
+
+        composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+        assert(dismissed)
+    }
+
+}

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
@@ -13,22 +13,13 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasType
-import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.Screen
-import com.github.se.eduverse.viewmodel.PdfConverterViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -37,159 +28,171 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.any
-import java.util.concurrent.CompletableFuture.allOf
 
 @RunWith(AndroidJUnit4::class)
 class PdfConverterScreenTest {
 
-    private lateinit var mockNavigationActions: NavigationActions
+  private lateinit var mockNavigationActions: NavigationActions
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Before
-    fun setUp() {
-        Intents.init()
+  @Before
+  fun setUp() {
+    Intents.init()
 
-        mockNavigationActions = mock(NavigationActions::class.java)
+    mockNavigationActions = mock(NavigationActions::class.java)
 
-        `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.PDF_CONVERTER)
+    `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.PDF_CONVERTER)
+  }
+
+  @After
+  fun tearDown() {
+    Intents.release()
+  }
+
+  @Test
+  fun topNavigationBarIsCorrectlyDisplayed() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions) }
+    composeTestRule.onNodeWithTag("topNavigationBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screenTitle").assertTextEquals("PDF Converter")
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
+    verify(mockNavigationActions).goBack()
+  }
+
+  @Test
+  fun allPdfConverterOptionsAreCorrectlyDisplayed() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name)
+        .assertTextEquals("Text to PDF")
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name)
+        .assertTextEquals("Image to PDF")
+    composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertHasClickAction()
+    composeTestRule
+        .onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name)
+        .assertTextEquals("Scanner tool")
+    composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertHasClickAction()
+    composeTestRule
+        .onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name)
+        .assertTextEquals("Summarize file")
+    composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertHasClickAction()
+    composeTestRule
+        .onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name)
+        .assertTextEquals("Extract text")
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun clickingTextToPdfOption_launchesFilePicker() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions) }
+
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-document-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+
+    composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun clickingImageToPdfOption_launchesFilePicker() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-image-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun testPdfNameInputDialog() {
+    composeTestRule.setContent {
+      PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = {})
     }
 
-    @After
-    fun tearDown() {
-        Intents.release()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("pdfNameInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("test.pdf")
+    composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("PDF File Name")
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsEnabled()
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertTextEquals("Create PDF")
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertTextEquals("Cancel")
+  }
+
+  @Test
+  fun testPdfNameInputDialog_confirmButtonDisabledWithEmptyFileName() {
+    composeTestRule.setContent {
+      PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = {})
     }
 
-    @Test
-    fun topNavigationBarIsCorrectlyDisplayed() {
-        composeTestRule.setContent {
-            PdfConverterScreen(mockNavigationActions)
-        }
-        composeTestRule.onNodeWithTag("topNavigationBar").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("screenTitle").assertTextEquals("PDF Converter")
-        composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("goBackButton").performClick()
-        verify(mockNavigationActions).goBack()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsNotEnabled()
+  }
+
+  @Test
+  fun testPdfNameInputDialog_confirm() {
+    var confirmedFileName = ""
+    composeTestRule.setContent {
+      PdfNameInputDialog(
+          pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
+    }
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    assert(confirmedFileName == "test.pdf")
+  }
+
+  @Test
+  fun testPdfNameInputDialog_confirmCallsOnConfirm() {
+    var confirmedFileName = ""
+    composeTestRule.setContent {
+      PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = { confirmedFileName = it })
+    }
+    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    assert(confirmedFileName == "test.pdf")
+  }
+
+  @Test
+  fun testPdfNameInputDialog_confirmWithoutInputKeepsDefaultFileName() {
+    var confirmedFileName = ""
+    composeTestRule.setContent {
+      PdfNameInputDialog(
+          pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
     }
 
-    @Test
-    fun allPdfConverterOptionsAreCorrectlyDisplayed() {
-        composeTestRule.setContent {
-            PdfConverterScreen(mockNavigationActions)
-        }
-        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertTextEquals("Text to PDF")
-        composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertTextEquals("Image to PDF")
-        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertHasClickAction()
-        composeTestRule.onNodeWithTag(PdfConverterOption.SCANNER_TOOL.name).assertTextEquals("Scanner tool")
-        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertHasClickAction()
-        composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertTextEquals("Summarize file")
-        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertHasClickAction()
-        composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertTextEquals("Extract text")
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    assert(confirmedFileName == "test.pdf")
+  }
+
+  @Test
+  fun testPdfNameInputDialog_callsOnDismissWhenCancelPressed() {
+    var dismissed = false
+    composeTestRule.setContent {
+      PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = { dismissed = true }, onConfirm = {})
     }
 
-    @Test
-    fun clickingTextToPdfOption_launchesFilePicker() {
-        composeTestRule.setContent {
-            PdfConverterScreen(mockNavigationActions)
-        }
-
-        // Set up the activity result for the intent
-        // Simulate the file picker intent
-        val expectedUri = Uri.parse("content://test-document-uri")
-        val resultIntent = Intent().apply { data = expectedUri }
-        Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
-    }
-
-    @Test
-    fun clickingImageToPdfOption_launchesFilePicker() {
-        composeTestRule.setContent {
-            PdfConverterScreen(mockNavigationActions)
-        }
-        composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    }
-
-    @Test
-    fun testPdfNameInputDialog() {
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = {})
-        }
-
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("pdfNameInput").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("test.pdf")
-        composeTestRule.onNodeWithTag("pdfNameInput").assertTextContains("PDF File Name")
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsEnabled()
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertTextEquals("Create PDF")
-        composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("dismissCreatePdfButton").assertTextEquals("Cancel")
-    }
-
-    @Test
-    fun testPdfNameInputDialog_confirmButtonDisabledWithEmptyFileName() {
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = {})
-        }
-
-        composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").assertIsNotEnabled()
-    }
-
-    @Test
-    fun testPdfNameInputDialog_confirm() {
-        var confirmedFileName = ""
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
-        }
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-        assert(confirmedFileName == "test.pdf")
-    }
-
-    @Test
-    fun testPdfNameInputDialog_confirmCallsOnConfirm() {
-        var confirmedFileName = ""
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = { confirmedFileName = it })
-        }
-        composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-        assert(confirmedFileName == "test.pdf")
-    }
-
-    @Test
-    fun testPdfNameInputDialog_confirmWithoutInputKeepsDefaultFileName() {
-        var confirmedFileName = ""
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
-        }
-
-        composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-        assert(confirmedFileName == "test.pdf")
-    }
-
-    @Test
-    fun testPdfNameInputDialog_callsOnDismissWhenCancelPressed() {
-        var dismissed = false
-        composeTestRule.setContent {
-            PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = { dismissed = true }, onConfirm = {})
-        }
-
-        composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-        assert(dismissed)
-    }
-
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+    assert(dismissed)
+  }
 }

--- a/app/src/main/java/com/github/se/eduverse/Extensions.kt
+++ b/app/src/main/java/com/github/se/eduverse/Extensions.kt
@@ -1,0 +1,15 @@
+/** Extensions.kt - A Kotlin file containing extension functions useful for the application */
+package com.github.se.eduverse
+
+import android.content.Context
+import android.widget.Toast
+
+/**
+ * Extension function to show a toast message in the context
+ *
+ * @param message Message to be displayed in the toast
+ * @param duration Duration for which the toast should be displayed
+ */
+fun Context.showToast(message: String, duration: Int = Toast.LENGTH_SHORT) {
+  Toast.makeText(this, message, duration).show()
+}

--- a/app/src/main/java/com/github/se/eduverse/model/Folder.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/Folder.kt
@@ -1,4 +1,4 @@
-package com.github.se.eduverse.model.folder
+package com.github.se.eduverse.model
 
 data class Folder(
     val ownerID: String,

--- a/app/src/main/java/com/github/se/eduverse/model/MyFile.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/MyFile.kt
@@ -1,4 +1,4 @@
-package com.github.se.eduverse.model.folder
+package com.github.se.eduverse.model
 
 import java.util.Calendar
 

--- a/app/src/main/java/com/github/se/eduverse/repository/FolderRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/FolderRepository.kt
@@ -1,4 +1,6 @@
-package com.github.se.eduverse.model.folder
+package com.github.se.eduverse.repository
+
+import com.github.se.eduverse.model.Folder
 
 interface FolderRepository {
   fun getFolders(userId: String, onSuccess: (List<Folder>) -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
@@ -1,0 +1,33 @@
+package com.github.se.eduverse.ui.converter
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.github.se.eduverse.ui.navigation.NavigationActions
+
+
+@Composable
+fun PdfConverterScreen(navigationActions: NavigationActions) {
+  Scaffold(floatingActionButton = {
+      FloatingActionButton(
+          onClick = { /*TODO*/ },
+          content = { Icon(Icons.Filled.Add, contentDescription = "Add new pdf") }
+      )
+  }) { pd ->
+    Column(modifier = Modifier.padding(pd)){
+
+    }
+
+}}

--- a/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
@@ -35,7 +35,7 @@ enum class PdfConverterOption {
   SCANNER_TOOL,
   SUMMARIZE_FILE,
   EXTRACT_TEXT,
-    NONE
+  NONE
 }
 
 /**
@@ -122,7 +122,7 @@ fun PdfConverterScreen(
                   }
 
               OptionCard(
-                    testTag = PdfConverterOption.EXTRACT_TEXT.name,
+                  testTag = PdfConverterOption.EXTRACT_TEXT.name,
                   optionName = "Extract text",
                   icon = Icons.Default.Abc,
                   onClick = {
@@ -145,7 +145,8 @@ fun PdfConverterScreen(
         onConfirm = { name ->
           converterViewModel.setNewFileName(name)
           showNameInputDialog = false
-          when (currentPdfConverterOption) { // For each option, the corresponding actions are performed
+          when (currentPdfConverterOption) { // For each option, the corresponding actions are
+                                             // performed
             PdfConverterOption.TEXT_TO_PDF -> {
               converterViewModel.convertDocumentToPdf(selectedFileUri, context)
             }
@@ -190,7 +191,11 @@ fun PdfNameInputDialog(pdfFileName: String, onDismiss: () -> Unit, onConfirm: (S
               Text("Create PDF")
             }
       },
-      dismissButton = { Button(onClick = onDismiss, modifier = Modifier.testTag("dismissCreatePdfButton")) { Text("Cancel") } })
+      dismissButton = {
+        Button(onClick = onDismiss, modifier = Modifier.testTag("dismissCreatePdfButton")) {
+          Text("Cancel")
+        }
+      })
 }
 
 /**
@@ -205,8 +210,7 @@ fun PdfNameInputDialog(pdfFileName: String, onDismiss: () -> Unit, onConfirm: (S
 @Composable
 fun OptionCard(testTag: String, optionName: String, icon: ImageVector, onClick: () -> Unit) {
   Card(
-      modifier =
-          Modifier.padding(16.dp).size(150.dp).clickable(onClick = onClick).testTag(testTag),
+      modifier = Modifier.padding(16.dp).size(150.dp).clickable(onClick = onClick).testTag(testTag),
       elevation = CardDefaults.cardElevation(8.dp),
       colors = CardDefaults.cardColors(containerColor = Color(0xFFC2F5F0))) {
         Column(

--- a/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
@@ -1,33 +1,238 @@
 package com.github.se.eduverse.ui.converter
 
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Button
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.automirrored.filled.TextSnippet
+import androidx.compose.material.icons.filled.Abc
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Scanner
+import androidx.compose.material.icons.filled.Summarize
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.TopNavigationBar
+import com.github.se.eduverse.viewmodel.PdfConverterViewModel
 
+// Enum class to list the different options available in the PDF converter tool
+enum class PdfConverterOption {
+  TEXT_TO_PDF,
+  IMAGE_TO_PDF,
+  SCANNER_TOOL,
+  SUMMARIZE_FILE,
+  EXTRACT_TEXT,
+    NONE
+}
 
+/**
+ * Composable for the PDF converter tool screen
+ *
+ * @param navigationActions Actions to be performed for navigation
+ * @param converterViewModel ViewModel for the PDF converter screen
+ */
 @Composable
-fun PdfConverterScreen(navigationActions: NavigationActions) {
-  Scaffold(floatingActionButton = {
-      FloatingActionButton(
-          onClick = { /*TODO*/ },
-          content = { Icon(Icons.Filled.Add, contentDescription = "Add new pdf") }
-      )
-  }) { pd ->
-    Column(modifier = Modifier.padding(pd)){
+fun PdfConverterScreen(
+    navigationActions: NavigationActions,
+    converterViewModel: PdfConverterViewModel = viewModel()
+) {
+  val context = LocalContext.current
+  var selectedFileUri by remember { mutableStateOf<Uri?>(null) }
+  var showNameInputDialog by remember { mutableStateOf(false) }
+  val pdfFileName = converterViewModel.newFileName.collectAsState()
+  var currentPdfConverterOption by remember { mutableStateOf(PdfConverterOption.NONE) }
 
+  // Launcher for opening the android file picker launcher
+  val filePickerLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        uri?.let { selectedFileUri = it }
+        if (selectedFileUri != null) {
+          val defaultFileName = getFileNameFromUri(context, selectedFileUri!!)
+          converterViewModel.setNewFileName(defaultFileName)
+          showNameInputDialog = true
+        } else {
+          Toast.makeText(context, "No file selected", Toast.LENGTH_LONG).show()
+        }
+      }
+
+  Scaffold(
+      topBar = {
+        TopNavigationBar(screenTitle = "PDF Converter", navigationActions = navigationActions)
+      }) { pd ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(pd),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceEvenly) {
+                    OptionCard(
+                        testTag = PdfConverterOption.TEXT_TO_PDF.name,
+                        optionName = "Text to PDF",
+                        icon = Icons.AutoMirrored.Filled.TextSnippet,
+                        onClick = {
+                          currentPdfConverterOption = PdfConverterOption.TEXT_TO_PDF
+                          filePickerLauncher.launch(
+                              arrayOf(
+                                  "text/plain",
+                                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document"))
+                        })
+                    OptionCard(
+                        testTag = PdfConverterOption.IMAGE_TO_PDF.name,
+                        optionName = "Image to PDF",
+                        icon = Icons.Default.Image,
+                        onClick = {
+                          currentPdfConverterOption = PdfConverterOption.IMAGE_TO_PDF
+                          filePickerLauncher.launch(arrayOf("image/*"))
+                        })
+                  }
+
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceEvenly) {
+                    OptionCard(
+                        testTag = PdfConverterOption.SCANNER_TOOL.name,
+                        optionName = "Scanner tool",
+                        icon = Icons.Default.Scanner,
+                        onClick = {
+                          currentPdfConverterOption = PdfConverterOption.SCANNER_TOOL
+                          Toast.makeText(context, "Not available yet", Toast.LENGTH_LONG).show()
+                        })
+                    OptionCard(
+                        testTag = PdfConverterOption.SUMMARIZE_FILE.name,
+                        optionName = "Summarize file",
+                        icon = Icons.Default.Summarize,
+                        onClick = {
+                          currentPdfConverterOption = PdfConverterOption.SUMMARIZE_FILE
+                          Toast.makeText(context, "Not available yet", Toast.LENGTH_LONG).show()
+                        })
+                  }
+
+              OptionCard(
+                    testTag = PdfConverterOption.EXTRACT_TEXT.name,
+                  optionName = "Extract text",
+                  icon = Icons.Default.Abc,
+                  onClick = {
+                    currentPdfConverterOption = PdfConverterOption.EXTRACT_TEXT
+                    Toast.makeText(context, "Not available yet", Toast.LENGTH_LONG).show()
+                  })
+            }
+      }
+
+  // Ask for the name of the PDF file to be created when the file to be converted is selected, and
+  // launch the file convertion once the name is selected
+  if (showNameInputDialog) {
+    PdfNameInputDialog(
+        pdfFileName = pdfFileName.value,
+        onDismiss = {
+          showNameInputDialog = false
+          selectedFileUri = null
+          Toast.makeText(context, "PDF creation canceled", Toast.LENGTH_SHORT).show()
+        }, // On dismiss the pdf file creation is aborted
+        onConfirm = { name ->
+          converterViewModel.setNewFileName(name)
+          showNameInputDialog = false
+          when (currentPdfConverterOption) { // For each option, the corresponding actions are performed
+            PdfConverterOption.TEXT_TO_PDF -> {
+              converterViewModel.convertDocumentToPdf(selectedFileUri, context)
+            }
+            PdfConverterOption.IMAGE_TO_PDF -> {
+              converterViewModel.convertImageToPdf(selectedFileUri, context)
+            }
+            else -> {}
+          }
+          currentPdfConverterOption = PdfConverterOption.NONE // Reset the selected option
+          selectedFileUri = null // Reset the selected file URI
+        })
+  }
+}
+
+/**
+ * Composable for displaying a dialog to input the name of the PDF file to be created
+ *
+ * @param pdfFileName Default name of the PDF file
+ * @param onDismiss Action to be performed when the dialog is dismissed
+ * @param onConfirm Action to be performed when the dialog is confirmed
+ */
+@Composable
+fun PdfNameInputDialog(pdfFileName: String, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+  var inputText by remember { mutableStateOf(pdfFileName) } // Initialized with the default name
+
+  AlertDialog(
+      modifier = Modifier.testTag("pdfNameInputDialog"),
+      onDismissRequest = onDismiss,
+      title = { Text("Enter the name of the PDF file") },
+      text = {
+        OutlinedTextField(
+            modifier = Modifier.testTag("pdfNameInput"),
+            value = inputText,
+            onValueChange = { inputText = it },
+            label = { Text("PDF File Name") })
+      },
+      confirmButton = {
+        Button(
+            modifier = Modifier.testTag("confirmCreatePdfButton"),
+            enabled = inputText.isNotEmpty(), // If input text is empty confirm button is disabled
+            onClick = { onConfirm(inputText) }) {
+              Text("Create PDF")
+            }
+      },
+      dismissButton = { Button(onClick = onDismiss, modifier = Modifier.testTag("dismissCreatePdfButton")) { Text("Cancel") } })
+}
+
+/**
+ * Composable for displaying the options of possible actions that can be performed within the PDF
+ * converter tool
+ *
+ * @param testTag Test tag for the option
+ * @param optionName Name of the option
+ * @param icon Icon for the option
+ * @param onClick Action to be performed when the option is clicked
+ */
+@Composable
+fun OptionCard(testTag: String, optionName: String, icon: ImageVector, onClick: () -> Unit) {
+  Card(
+      modifier =
+          Modifier.padding(16.dp).size(150.dp).clickable(onClick = onClick).testTag(testTag),
+      elevation = CardDefaults.cardElevation(8.dp),
+      colors = CardDefaults.cardColors(containerColor = Color(0xFFC2F5F0))) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center) {
+              Icon(imageVector = icon, contentDescription = null, Modifier.size(80.dp))
+              Text(optionName)
+            }
+      }
+}
+
+/**
+ * Helper function to retrieve the file name from a the uri of a file
+ *
+ * @param context Context of the application
+ * @param uri URI of the file
+ * @return Name of the file
+ */
+private fun getFileNameFromUri(context: Context, uri: Uri): String {
+  var fileName = ""
+  val cursor = context.contentResolver.query(uri, null, null, null, null)
+  cursor?.use {
+    if (it.moveToFirst()) {
+      fileName = it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
     }
-
-}}
+  }
+  return fileName.substringBeforeLast(".") // Return the name without the file extension
+}

--- a/app/src/main/java/com/github/se/eduverse/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/navigation/NavigationActions.kt
@@ -28,6 +28,7 @@ object Screen {
   const val EDIT_PROFILE = "EditProfile screen"
   const val FOLDER = "Folder screen"
   const val COURSES = "Courses screen"
+  const val PDF_CONVERTER = "PdfConverter screen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
@@ -60,7 +61,7 @@ open class NavigationActions(
    *   navigating to a new destination This is useful when navigating to a new screen from the
    *   bottom navigation bar as we don't want to keep the previous screen in the back stack
    */
-  fun navigateTo(destination: TopLevelDestination) {
+  open fun navigateTo(destination: TopLevelDestination) {
 
     navController.navigate(destination.route) {
       // Pop up to the start destination of the graph to
@@ -85,12 +86,12 @@ open class NavigationActions(
    *
    * @param screen The screen to navigate to
    */
-  fun navigateTo(screen: String) {
+  open fun navigateTo(screen: String) {
     navController.navigate(screen)
   }
 
   /** Navigate back to the previous screen. */
-  fun goBack() {
+  open fun goBack() {
     navController.popBackStack()
   }
 
@@ -99,7 +100,7 @@ open class NavigationActions(
    *
    * @return The current route
    */
-  fun currentRoute(): String {
+  open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""
   }
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/navigation/TopNavigationBar.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/navigation/TopNavigationBar.kt
@@ -1,0 +1,26 @@
+package com.github.se.eduverse.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopNavigationBar(screenTitle: String, navigationActions: NavigationActions) {
+  TopAppBar(
+      modifier = Modifier.testTag("topNavigationBar"),
+      title = { Text(screenTitle, Modifier.testTag("screenTitle")) },
+      navigationIcon = {
+        IconButton(
+            modifier = Modifier.testTag("goBackButton"), onClick = { navigationActions.goBack() }) {
+              Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+            }
+      })
+}

--- a/app/src/main/java/com/github/se/eduverse/ui/others/Others.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/others/Others.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.sp
 import com.github.se.eduverse.ui.navigation.BottomNavigationMenu
 import com.github.se.eduverse.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Screen
 
 @Composable
 fun OthersScreen(navigationActions: NavigationActions) {
@@ -71,22 +72,22 @@ fun OthersScreen(navigationActions: NavigationActions) {
 
               Spacer(modifier = Modifier.height(16.dp))
 
-              // Field #4 button
+              // Pdf Converter
               Button(
-                  onClick = { /* Placeholder for Field #4 */},
+                  onClick = { navigationActions.navigateTo(Screen.PDF_CONVERTER)},
                   modifier =
                       Modifier.fillMaxWidth()
                           .height(50.dp)
-                          .testTag("field4Button") // Test tag for Field #4 button
+                          .testTag("pdfConverterButton") // Test tag for Field #4 button
                   ) {
-                    Text(text = "Field #4", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+                    Text(text = "Pdf Converter", fontSize = 20.sp, fontWeight = FontWeight.Bold)
                   }
 
               Spacer(modifier = Modifier.height(16.dp))
 
               // Field #5 button
               Button(
-                  onClick = { /* Placeholder for Field #5 */},
+                  onClick = {  },
                   modifier =
                       Modifier.fillMaxWidth()
                           .height(50.dp)

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/FolderViewModel.kt
@@ -1,7 +1,11 @@
-package com.github.se.eduverse.model.folder
+package com.github.se.eduverse.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.github.se.eduverse.model.FilterTypes
+import com.github.se.eduverse.model.Folder
+import com.github.se.eduverse.model.MyFile
+import com.github.se.eduverse.repository.FolderRepository
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
@@ -1,14 +1,260 @@
 package com.github.se.eduverse.viewmodel
 
-#generate the imports
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.pdf.PdfDocument
+import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
-import com.github.se.eduverse.model.Folder
+import androidx.lifecycle.viewModelScope
+import com.github.se.eduverse.showToast
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-open class PdfConverterViewModel(){
-    private val _selectedFolder = MutableStateFlow<Folder?>(null)
-    val selectedFolder: StateFlow<Folder?> = _selectedFolder.asStateFlow()
+open class PdfConverterViewModel : ViewModel() {
 
+  private val newFileName_ = MutableStateFlow<String>("")
+  val newFileName: StateFlow<String> = newFileName_.asStateFlow()
+
+
+  /**
+   * Set the new file name for the PDF to be created
+   *
+   * @param pdfFileName The new file name for the PDF
+   */
+  fun setNewFileName(pdfFileName: String) {
+    // Sanitize the file name to prevent malicious file names
+    val sanitizedFileName = pdfFileName.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+    newFileName_.value = sanitizedFileName
+  }
+
+  /**
+   * Convert the image corresponding to the given URI to a PDF
+   *
+   * @param imageUri The URI of the image to convert
+   * @param context The context of the application
+   */
+  fun convertImageToPdf(imageUri: Uri?, context: Context) {
+    viewModelScope.launch(Dispatchers.IO) {
+      try {
+        // Read the image bitmap from the URI and display a toast if the inputStream fails to open
+        val imageBitmap =
+            context.contentResolver.openInputStream(imageUri!!)?.use { inputStream ->
+              BitmapFactory.decodeStream(inputStream)
+            } ?: run {
+                  withContext(Dispatchers.Main) {
+                    Log.e("convertImageToPdf", "Failed to decode image")
+                    context.showToast("Failed to open image")
+                  }
+                  return@launch
+                }
+
+        // Create a new PDF document and add the image to it
+        val pdfDocument = PdfDocument()
+        val pageInfo =
+            PdfDocument.PageInfo.Builder(imageBitmap.width, imageBitmap.height, 1)
+                .create() // The pdf page will have the same size as the input image
+        val page = pdfDocument.startPage(pageInfo)
+        val canvas = page.canvas
+        canvas.drawBitmap(
+            imageBitmap,
+            0f,
+            0f,
+            null) // Draw the image on the canvas starting from the top-left corner
+        pdfDocument.finishPage(page)
+
+        // Create the PDF file, write the document to it, and generate a toast if the file creation
+        // is successful
+        val file =
+            createUniqueFile(
+                context.filesDir,
+                "${newFileName_.value}.pdf") // For now, save the PDF in the app's files directory,
+        // later will add option to give user choice of
+        // location
+        FileOutputStream(file).use { outputStream -> pdfDocument.writeTo(outputStream) }
+        pdfDocument.close()
+        withContext(Dispatchers.Main) {
+          context.showToast("PDF created successfully")
+        }
+      } catch (e: Exception) {
+        // If an exception occurs during the conversion process, log the error and display a toast
+        Log.e("convertImageToPdf", "Image conversion failed", e)
+        withContext(Dispatchers.Main) {
+          context.showToast("Failed to create PDF")
+        }
+      }
+    }
+  }
+
+  /**
+   * Convert the document corresponding to the given URI to a PDF (for now only handles .docx and
+   * .txt files, will add later other file types)
+   *
+   * @param fileUri The URI of the document to convert
+   * @param context The context of the application
+   */
+  fun convertDocumentToPdf(fileUri: Uri?, context: Context) {
+    val mimeType = context.contentResolver.getType(fileUri!!)
+    when (mimeType) {
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document" -> {
+        convertWordToPdf(fileUri, context)
+      }
+      "text/plain" -> {
+        convertTextToPdf(fileUri, context)
+      }
+      // Not needed because the file picker only allows the selection of text and word files, but
+      // kept to be safe
+      else -> {
+        context.showToast("Unsupported file type")
+      }
+    }
+  }
+
+  /**
+   * Convert the text file corresponding to the given URI to a PDF document
+   *
+   * @param fileUri The URI of the text file to convert
+   * @param context The context of the application
+   */
+  fun convertTextToPdf(fileUri: Uri, context: Context) {
+    viewModelScope.launch(Dispatchers.IO) {
+      try {
+        // Open the text file input stream and create a buffered reader on it, display a toast if
+        // the file fails to open
+        val inputStream = context.contentResolver.openInputStream(fileUri)
+        val bufferedReader =
+            inputStream?.bufferedReader()
+                ?: run {
+                  withContext(Dispatchers.Main) {
+                    Log.e("convertTextToPdf", "Failed to open text file")
+                    context.showToast("Failed to open text file")
+                  }
+                  return@launch
+                }
+
+        // Create a new PDF document
+        val pdfDocument = PdfDocument()
+        val pageInfo = PdfDocument.PageInfo.Builder(595, 842, 1).create() // A4 page size
+        var page = pdfDocument.startPage(pageInfo)
+        var canvas = page.canvas
+        val paint =
+            Paint()
+                .apply { // Set the paint properties for the text to be written on the pdf document
+                  isAntiAlias = true
+                  textSize = 12f
+                  color = Color.BLACK
+                }
+        var yPosition = 40f // Start writing the text from 40px from the top of the page
+
+        // Read the text from the file in buffered way to avoid memory issues
+        bufferedReader.use { reader ->
+          var line: String?
+          while (reader.readLine().also { line = it } != null) {
+            // Split the line into words to avoid overflowing the page width in case of long lines
+            val words = line!!.split(" ")
+
+            // Draw the read line word by word into the pdf document
+            var currentLine = ""
+            for (word in words) {
+              // Check if the line with the next word fits in the pdf page width
+              val tempLine =
+                  if (currentLine.isEmpty()) word
+                  else "$currentLine $word" // Add the next word to the current line after a space,
+              // for the first line of the doc no space needed before
+              // the word
+              val textWidth = paint.measureText(tempLine)
+              if (textWidth <= pageInfo.pageWidth - 40) { // 20px padding on each side of the page
+                currentLine = tempLine
+              } else {
+                // Draw the current line and start a new line with the current word
+                canvas.drawText(currentLine, 20f, yPosition, paint)
+                yPosition += paint.descent() - paint.ascent()
+                currentLine = word
+              }
+
+              // If the current page is full, create a new page and add it to the pdf document
+              if (yPosition >
+                  pageInfo.pageHeight - 80) { // 40px padding on top and bottom of the page
+                pdfDocument.finishPage(page)
+                yPosition = 40f
+                val newPageInfo =
+                    PdfDocument.PageInfo.Builder(595, 842, pdfDocument.pages.size + 1).create()
+                page = pdfDocument.startPage(newPageInfo)
+                canvas = page.canvas
+              }
+            }
+
+            // Draw the last word of the read line if it didn't fit in the page's previous line
+            if (currentLine.isNotEmpty()) {
+              canvas.drawText(currentLine, 10f, yPosition, paint)
+              yPosition += paint.descent() - paint.ascent()
+            }
+
+            // If the last word of the read line was written on the last line of the page, create a
+            // new page
+            if (yPosition > pageInfo.pageHeight - 40) {
+              pdfDocument.finishPage(page)
+              yPosition = 40f
+              val newPageInfo =
+                  PdfDocument.PageInfo.Builder(595, 842, pdfDocument.pages.size + 1).create()
+              page = pdfDocument.startPage(newPageInfo)
+              canvas = page.canvas
+            }
+          }
+        }
+
+        // Finish the last page and write the pdf document to the destination file, display a toast
+        // if document creation is successful
+        pdfDocument.finishPage(page)
+        val file = createUniqueFile(context.filesDir, "${newFileName_.value}.pdf")
+        FileOutputStream(file).use { outputStream -> pdfDocument.writeTo(outputStream) }
+        pdfDocument.close()
+        withContext(Dispatchers.Main) {
+          context.showToast("PDF created successfully")
+        }
+      } catch (e: Exception) {
+        // If an exception occurs during the conversion process, log the error and display a toast
+        Log.e("convertTextToPdf", "Text conversion failed", e)
+        withContext(Dispatchers.Main) {
+            context.showToast("Failed to create PDF")
+        }
+      }
+    }
+  }
+
+  // Not implemented yet
+  fun convertWordToPdf(fileUri: Uri, context: Context) {
+    viewModelScope.launch { context.showToast("Not implemented yet") }
+  }
+
+  /**
+   * Helper function to create a unique file in the specified directory with the given file name,if
+   * the file already exists it will append a number to the file name to make it unique (like it's
+   * done by the mac os file system)
+   *
+   * @param directory The directory where to create the file
+   * @param fileName The name of the file to create
+   * @return The created file
+   */
+  private fun createUniqueFile(directory: File, fileName: String): File {
+    var file = File(directory, fileName)
+    var fileIndex = 1
+    val baseName = fileName.substringBeforeLast(".")
+    val extension = fileName.substringAfterLast(".", "")
+
+    while (file.exists()) {
+      val newFileName = "$baseName($fileIndex).$extension"
+      file = File(directory, newFileName)
+      fileIndex++
+    }
+    return file
+  }
 }

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
@@ -24,7 +24,6 @@ open class PdfConverterViewModel : ViewModel() {
   private val newFileName_ = MutableStateFlow<String>("")
   val newFileName: StateFlow<String> = newFileName_.asStateFlow()
 
-
   /**
    * Set the new file name for the PDF to be created
    *
@@ -49,7 +48,8 @@ open class PdfConverterViewModel : ViewModel() {
         val imageBitmap =
             context.contentResolver.openInputStream(imageUri!!)?.use { inputStream ->
               BitmapFactory.decodeStream(inputStream)
-            } ?: run {
+            }
+                ?: run {
                   withContext(Dispatchers.Main) {
                     Log.e("convertImageToPdf", "Failed to decode image")
                     context.showToast("Failed to open image")
@@ -81,15 +81,11 @@ open class PdfConverterViewModel : ViewModel() {
         // location
         FileOutputStream(file).use { outputStream -> pdfDocument.writeTo(outputStream) }
         pdfDocument.close()
-        withContext(Dispatchers.Main) {
-          context.showToast("PDF created successfully")
-        }
+        withContext(Dispatchers.Main) { context.showToast("PDF created successfully") }
       } catch (e: Exception) {
         // If an exception occurs during the conversion process, log the error and display a toast
         Log.e("convertImageToPdf", "Image conversion failed", e)
-        withContext(Dispatchers.Main) {
-          context.showToast("Failed to create PDF")
-        }
+        withContext(Dispatchers.Main) { context.showToast("Failed to create PDF") }
       }
     }
   }
@@ -217,15 +213,11 @@ open class PdfConverterViewModel : ViewModel() {
         val file = createUniqueFile(context.filesDir, "${newFileName_.value}.pdf")
         FileOutputStream(file).use { outputStream -> pdfDocument.writeTo(outputStream) }
         pdfDocument.close()
-        withContext(Dispatchers.Main) {
-          context.showToast("PDF created successfully")
-        }
+        withContext(Dispatchers.Main) { context.showToast("PDF created successfully") }
       } catch (e: Exception) {
         // If an exception occurs during the conversion process, log the error and display a toast
         Log.e("convertTextToPdf", "Text conversion failed", e)
-        withContext(Dispatchers.Main) {
-            context.showToast("Failed to create PDF")
-        }
+        withContext(Dispatchers.Main) { context.showToast("Failed to create PDF") }
       }
     }
   }

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
@@ -1,0 +1,14 @@
+package com.github.se.eduverse.viewmodel
+
+#generate the imports
+import androidx.lifecycle.ViewModel
+import com.github.se.eduverse.model.Folder
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+open class PdfConverterViewModel(){
+    private val _selectedFolder = MutableStateFlow<Folder?>(null)
+    val selectedFolder: StateFlow<Folder?> = _selectedFolder.asStateFlow()
+
+}

--- a/app/src/test/java/com/github/se/eduverse/ui/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/ui/NavigationActionsTest.kt
@@ -1,8 +1,12 @@
-package com.github.se.eduverse.ui.navigation
+package com.github.se.eduverse.ui
 
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
+import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Route
+import com.github.se.eduverse.ui.navigation.Screen
+import com.github.se.eduverse.ui.navigation.TopLevelDestinations
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/FolderViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/FolderViewModelTest.kt
@@ -1,5 +1,9 @@
-package com.github.se.eduverse.model.folder
+package com.github.se.eduverse.viewmodel
 
+import com.github.se.eduverse.model.FilterTypes
+import com.github.se.eduverse.model.Folder
+import com.github.se.eduverse.model.MyFile
+import com.github.se.eduverse.repository.FolderRepository
 import com.google.firebase.auth.FirebaseUser
 import java.util.Calendar
 import org.junit.Assert.assertEquals
@@ -20,9 +24,9 @@ class FolderViewModelTest {
 
   val file1 = MyFile("", "name 1", Calendar.getInstance(), Calendar.getInstance(), 0)
   val file2 =
-      MyFile("", "name 2", java.util.Calendar.getInstance(), java.util.Calendar.getInstance(), 0)
+      MyFile("", "name 2", Calendar.getInstance(), Calendar.getInstance(), 0)
   val file3 =
-      MyFile("", "name 3", java.util.Calendar.getInstance(), java.util.Calendar.getInstance(), 0)
+      MyFile("", "name 3", Calendar.getInstance(), Calendar.getInstance(), 0)
 
   @Before
   fun setUp() {
@@ -173,9 +177,9 @@ class FolderViewModelTest {
 class MockFolderRepository(private val folder: Folder) : FolderRepository {
 
   override fun getFolders(
-      userId: String,
-      onSuccess: (List<Folder>) -> Unit,
-      onFailure: (Exception) -> Unit
+    userId: String,
+    onSuccess: (List<Folder>) -> Unit,
+    onFailure: (Exception) -> Unit
   ) {
     onSuccess(
         List(1) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ okhttp = "4.12.0"
 
 # Testing Unit
 junit = "4.13.2"
-mockitoCore = "3.12.4"
+mockitoCore = "5.13.0"
 mockitoInline = "3.12.4"
 mockitoKotlin = "5.4.0"
 mockk = "1.13.7"


### PR DESCRIPTION
This PR implements a pdf converter feature, it offers to the user multiple ways to create pdf files:
- convert an image to a pdf file
- convert a text document to a pdf file (only files of type .txt and .docx are considered for now and only the conversion logic for .txt files is implemented in this pr)
- summarize a text document using AI (not implemented yet)
- extract text from a picture (not implemented yet)
- a scanner tool to scan documents and render them in a pdf file as if they were scanned using a scanning machine (not implemented yet)
These different tools allow the users to easily perform multiple actions in a centralized way. For now only the two first tools are implemented. Since students are often asked to submit their deliverables in pdf format, these two tools aim to provide them with the capability of converting their work products (essays, schemas, ...) to pdf files at a push of a button. 

<img width="345" alt="Capture d’écran 2024-10-18 à 01 15 31" src="https://github.com/user-attachments/assets/d3bb5cd5-0e49-4caf-8156-4673c215ee34">

It uses the `Card` composable to display the possible options in a pleasant way, and the `android.graphics.pdf` package to create the pdf documents.

For now on click on one of the two implemented options the android file picker is opened for the user to select the source file and after that an `AlertDialog` is displays for the user to enter the name he wants for the new pdf document. On successful creation of document the latter will be stored on the app private storage `filesDir` and a toast is displayed on the converter screen to notify the user, same in case of failure in generating the pdf document.

### Checklist:
- [x] Implement the converter screen
- [x] Implement the converter view model
- [x] Write tests for the converter screen
- [ ] Write tests for the converter view model
- [x] Update main activity to add pdf converter screen to navigation graph
- [x] Add apache poi api dependencies (will be used later to process microsoft word documents)
- [x] Update mockitoCore library version to latest to be able to use IntentMatchers in ui tests
- [x] Implement top navigation bar that is used in the pdf converter screen and will be used in other screens of the app
- [x] Update others screen to be able to navigate to the pdf converter from it
- [x] Add pdf converter screen to NavigationActions   
- [x] Add Extensions.kt, a file where to put all extension functions useful for the app, for now it only contains a Context extension function to show a toast on the context the function is called on
- [x] Format code with ktfmt
- [x] Document classes