### PR TITLE
Solve bug when rotating screen

### DIFF
--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -75,12 +75,6 @@ class MainActivity : ComponentActivity() {
 
     super.onCreate(savedInstanceState)
 
-    // Initialiser Firebase Auth
-    auth = FirebaseAuth.getInstance()
-    if (auth.currentUser != null) {
-      auth.signOut()
-    }
-
     // Instanciez le repository et le ViewModel
     val photoRepository =
         PhotoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())


### PR DESCRIPTION
### Bug description

When on the dashboard screen, if the screen was rotated, the user was disconnected and the app went back to the login screen. This behavior didn't happen with any other screens, but on some screens the app crashed when rotated.

### Origin

This came from a part of the MainApplication script. On creation of the application, there was a piece of code which loged out the user.

```
auth = FirebaseAuth.getInstance()
if (auth.currentUser != null) {
  auth.signOut()
}
```

It happens that, on rotation, a new app is constructed with the same data. But during the process, the onCreate method of MainActivity was called resulting in the unwanted behavior.

### Resolution

As it wasn't important to the app, I removed the above code. Appart from solving the bug, the only effect of this change is that, when the user is already logged in, the login screen no longer appears. As this happens to be the expected behavior according to discussions, it shouldn't create any problem.

### Edit

Turns out this was already changed in #101, not to solve the bug but to implement the feature of staying connected. As there is no point to keep both, I will delete this PR, but leave it as trace that the bug is no longer present in the app.