### PR TITLE
Implement the feature of adding photo and video to folders

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
@@ -289,9 +289,6 @@ class NextScreenTest {
     composeTestRule.onNodeWithTag("folder_button1").assertIsDisplayed()
     composeTestRule.onNodeWithTag("folder_button2").assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("folder_button1").performClick()
-    composeTestRule.onNodeWithTag("button_container").assertIsNotDisplayed()
-
     var test = false
     val func = slot<(String, String, Folder) -> Unit>()
     every { photoViewModel.savePhoto(any(), folder1, capture(func)) } answers
@@ -299,10 +296,14 @@ class NextScreenTest {
           test = true
           func.captured("id", "name", folder1)
         }
-    composeTestRule.onNodeWithTag("saveButton").performClick()
+    composeTestRule.onNodeWithTag("folder_button1").performClick()
+
+    composeTestRule.onNodeWithTag("button_container").assertIsNotDisplayed()
+
     assert(test)
     org.mockito.kotlin.verify(folderRepository).updateFolder(any(), any(), any())
     assertEquals(1, folder1.files.size)
+    verify(exactly = 3) { navigationActions.goBack() }
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
@@ -17,9 +17,9 @@ import com.github.se.eduverse.repository.FolderRepository
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
+import com.github.se.eduverse.viewmodel.VideoViewModel
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
-import com.github.se.eduverse.viewmodel.VideoViewModel
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -147,28 +147,13 @@ class NextScreenTest {
   }
 
   @Test
-  fun testAddLinkButtonIsClickable() {
-    composeTestRule.onNodeWithTag("addLinkButton").assertIsDisplayed().assertHasClickAction()
+  fun testAddToFolderButtonIsClickable() {
+    composeTestRule.onNodeWithTag("addToFolderButton").assertIsDisplayed().assertHasClickAction()
   }
 
   @Test
   fun testMoreOptionsButtonIsClickable() {
     composeTestRule.onNodeWithTag("moreOptionsButton").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  fun testSaveButtonCallsSavePhotoWithCorrectArguments() {
-    val capturedPhoto = slot<Photo>()
-    every { photoViewModel.savePhoto(capture(capturedPhoto), null, any()) } returns Unit
-
-    // Action : cliquer sur le bouton de sauvegarde
-    composeTestRule.onNodeWithTag("saveButton").performClick()
-
-    // Vérifier que `savePhoto` a été appelé avec un `Photo` ayant l'`ownerId` correct
-    assertEquals("anonymous", capturedPhoto.captured.ownerId)
-
-    // Vérifier que le `path` commence bien par le bon préfixe, sans vérifier le timestamp exact
-    assertTrue(capturedPhoto.captured.path.startsWith("media/anonymous/"))
   }
 
   @Test
@@ -189,7 +174,7 @@ class NextScreenTest {
 
   @Test
   fun testAddLinkAndMoreOptionsButtons() {
-    composeTestRule.onNodeWithTag("addLinkButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithTag("addToFolderButton").assertIsDisplayed().assertHasClickAction()
     composeTestRule.onNodeWithTag("moreOptionsButton").assertIsDisplayed().assertHasClickAction()
   }
 
@@ -233,7 +218,7 @@ class NextScreenTest {
 
     // Test sur le bouton "Add link"
     composeTestRule
-        .onNodeWithTag("addLinkButton")
+        .onNodeWithTag("addToFolderButton")
         .assertExists()
         .assertHasClickAction()
         .performClick()
@@ -294,8 +279,8 @@ class NextScreenTest {
       callback(listOf(folder1, folder2))
     }
 
-    composeTestRule.onNodeWithTag("addLinkButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("addLinkButton").performClick()
+    composeTestRule.onNodeWithTag("addToFolderButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addToFolderButton").performClick()
 
     composeTestRule.waitForIdle()
 
@@ -319,11 +304,11 @@ class NextScreenTest {
     org.mockito.kotlin.verify(folderRepository).updateFolder(any(), any(), any())
     assertEquals(1, folder1.files.size)
   }
-    
+
   @Test
   fun testSaveButtonCallsSavePhotoWithCorrectArguments() {
     val capturedPhoto = slot<Photo>()
-    every { pViewModel.savePhoto(capture(capturedPhoto)) } returns Unit
+    every { photoViewModel.savePhoto(capture(capturedPhoto)) } returns Unit
 
     // Action : cliquer sur le bouton de sauvegarde
     composeTestRule.onNodeWithTag("saveButton").performClick()

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
@@ -308,7 +308,7 @@ class NextScreenTest {
   @Test
   fun testSaveButtonCallsSavePhotoWithCorrectArguments() {
     val capturedPhoto = slot<Photo>()
-    every { photoViewModel.savePhoto(capture(capturedPhoto)) } returns Unit
+    every { photoViewModel.savePhoto(capture(capturedPhoto), any(), any()) } returns Unit
 
     // Action : cliquer sur le bouton de sauvegarde
     composeTestRule.onNodeWithTag("saveButton").performClick()

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest2.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest2.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.test.core.app.ApplicationProvider
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
 import io.mockk.mockk
 import java.io.File
@@ -21,7 +22,8 @@ class NextScreenTest2 {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navigationActions: NavigationActions
-  private lateinit var viewModel: PhotoViewModel
+  private lateinit var photoViewModel: PhotoViewModel
+  private lateinit var folderViewModel: FolderViewModel
   private lateinit var context: Context
   private var currentPhotoFile: File? = null
   private var currentVideoFile: File? = null
@@ -29,7 +31,8 @@ class NextScreenTest2 {
   @Before
   fun setUp() {
     navigationActions = mockk(relaxed = true)
-    viewModel = mockk(relaxed = true)
+    photoViewModel = mockk(relaxed = true)
+    folderViewModel = mockk(relaxed = true)
     context = ApplicationProvider.getApplicationContext()
 
     // Simuler un fichier image temporaire
@@ -50,7 +53,8 @@ class NextScreenTest2 {
           photoFile = currentPhotoFile,
           videoFile = currentVideoFile,
           navigationActions = navigationActions,
-          viewModel = viewModel)
+          photoViewModel = photoViewModel,
+          folderViewModel = folderViewModel)
     }
 
     // Forcer la recomposition
@@ -71,7 +75,8 @@ class NextScreenTest2 {
           photoFile = currentPhotoFile,
           videoFile = testVideoFile,
           navigationActions = navigationActions,
-          viewModel = viewModel)
+          photoViewModel = photoViewModel,
+          folderViewModel = folderViewModel)
     }
 
     // Forcer la recomposition

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/nextScreenTest3.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/nextScreenTest3.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.performClick
 import com.github.se.eduverse.model.Video
 import com.github.se.eduverse.ui.camera.NextScreen
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
 import com.github.se.eduverse.viewmodel.VideoViewModel
 import io.mockk.mockk
@@ -17,6 +18,7 @@ import org.mockito.Mockito.*
 class NextScreenTest3 {
 
   private lateinit var pViewModel: PhotoViewModel
+  private lateinit var fViewModel: FolderViewModel
   private lateinit var vViewModel: VideoViewModel
   private lateinit var navigationActions: NavigationActions
   private lateinit var testFile: File
@@ -25,6 +27,7 @@ class NextScreenTest3 {
   @Before
   fun setUp() {
     pViewModel = mockk(relaxed = true)
+    fViewModel = mockk(relaxed = true)
     vViewModel = mockk(relaxed = true)
     navigationActions = mockk(relaxed = true)
 
@@ -49,6 +52,7 @@ class NextScreenTest3 {
           videoFile = testVideoFile, // Fichier vidéo valide
           navigationActions = navigationActions,
           pViewModel,
+          fViewModel,
           vViewModel)
     }
 

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -72,7 +73,7 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var auth: FirebaseAuth
   private var cameraPermissionGranted by mutableStateOf(false)
-  
+
   private lateinit var videoViewModel: VideoViewModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -116,10 +117,7 @@ class MainActivity : ComponentActivity() {
 
 @SuppressLint("ComposableDestinationInComposeScope")
 @Composable
-fun EduverseApp(
-    cameraPermissionGranted: Boolean,
-    videoViewModel: VideoViewModel
-) {
+fun EduverseApp(cameraPermissionGranted: Boolean, videoViewModel: VideoViewModel) {
   val firestore = FirebaseFirestore.getInstance()
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -137,8 +135,8 @@ fun EduverseApp(
   val photoRepo = PhotoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
   val photoViewModel = PhotoViewModel(photoRepo, fileRepo)
 
-  val PubRepo = PublicationRepository(firestore)
-  val PublicationViewModel = PublicationViewModel(PubRepo)
+  val pubRepo = PublicationRepository(firestore)
+  val publicationViewModel = PublicationViewModel(pubRepo)
 
   NavHost(navController = navController, startDestination = Route.LOADING) {
     navigation(
@@ -167,7 +165,7 @@ fun EduverseApp(
         startDestination = Screen.VIDEOS,
         route = Route.VIDEOS,
     ) {
-      composable(Screen.VIDEOS) { VideoScreen(navigationActions, PublicationViewModel) }
+      composable(Screen.VIDEOS) { VideoScreen(navigationActions, publicationViewModel) }
     }
 
     navigation(

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -43,11 +42,11 @@ import com.github.se.eduverse.ui.folder.CreateFileScreen
 import com.github.se.eduverse.ui.folder.CreateFolderScreen
 import com.github.se.eduverse.ui.folder.FolderScreen
 import com.github.se.eduverse.ui.folder.ListFoldersScreen
+import com.github.se.eduverse.ui.gallery.GalleryScreen
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.Route
 import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.ui.profile.ProfileScreen
-import com.github.se.eduverse.ui.screens.GalleryScreen
 import com.github.se.eduverse.ui.setting.SettingsScreen
 import com.github.se.eduverse.ui.theme.EduverseTheme
 import com.github.se.eduverse.ui.videos.VideosScreen
@@ -55,7 +54,6 @@ import com.github.se.eduverse.viewmodel.DashboardViewModel
 import com.github.se.eduverse.viewmodel.FileViewModel
 import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
-import com.github.se.eduverse.viewmodel.PhotoViewModelFactory
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.TimerViewModel
 import com.google.firebase.auth.FirebaseAuth
@@ -69,7 +67,6 @@ class MainActivity : ComponentActivity() {
 
   private lateinit var auth: FirebaseAuth
   private var cameraPermissionGranted by mutableStateOf(false)
-  private lateinit var photoViewModel: PhotoViewModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -80,12 +77,6 @@ class MainActivity : ComponentActivity() {
     if (auth.currentUser != null) {
       auth.signOut()
     }
-
-    // Instanciez le repository et le ViewModel
-    val photoRepository =
-        PhotoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
-    val photoViewModelFactory = PhotoViewModelFactory(photoRepository)
-    photoViewModel = ViewModelProvider(this, photoViewModelFactory)[PhotoViewModel::class.java]
 
     // Gestion des permissions de la caméra
     val requestPermissionLauncher =
@@ -102,9 +93,7 @@ class MainActivity : ComponentActivity() {
 
     setContent {
       EduverseTheme {
-        Surface(modifier = Modifier.fillMaxSize()) {
-          EduverseApp(cameraPermissionGranted, photoViewModel)
-        }
+        Surface(modifier = Modifier.fillMaxSize()) { EduverseApp(cameraPermissionGranted) }
       }
     }
   }
@@ -112,7 +101,7 @@ class MainActivity : ComponentActivity() {
 
 @SuppressLint("ComposableDestinationInComposeScope")
 @Composable
-fun EduverseApp(cameraPermissionGranted: Boolean, photoViewModel: PhotoViewModel) {
+fun EduverseApp(cameraPermissionGranted: Boolean) {
   val firestore = FirebaseFirestore.getInstance()
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -127,6 +116,8 @@ fun EduverseApp(cameraPermissionGranted: Boolean, photoViewModel: PhotoViewModel
   val pomodoroViewModel: TimerViewModel = viewModel()
   val fileRepo = FileRepositoryImpl(db = firestore, storage = FirebaseStorage.getInstance())
   val fileViewModel = FileViewModel(fileRepo)
+  val photoRepo = PhotoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
+  val photoViewModel = PhotoViewModel(photoRepo, fileRepo)
 
   NavHost(navController = navController, startDestination = Route.LOADING) {
     navigation(
@@ -190,7 +181,8 @@ fun EduverseApp(cameraPermissionGranted: Boolean, photoViewModel: PhotoViewModel
 
       composable(Screen.GALLERY) {
         val ownerId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-        GalleryScreen(ownerId = ownerId, viewModel = photoViewModel, navigationActions)
+        GalleryScreen(
+            ownerId = ownerId, photoViewModel = photoViewModel, folderViewModel, navigationActions)
         Log.d("GalleryScreen", "Current Owner ID: $ownerId")
       }
     }
@@ -261,7 +253,8 @@ fun EduverseApp(cameraPermissionGranted: Boolean, photoViewModel: PhotoViewModel
               photoFile = photoFile,
               videoFile = videoFile,
               navigationActions = navigationActions,
-              photoViewModel)
+              photoViewModel,
+              folderViewModel)
         }
   }
 }

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -61,7 +60,6 @@ import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.PublicationViewModel
 import com.github.se.eduverse.viewmodel.TimerViewModel
 import com.github.se.eduverse.viewmodel.VideoViewModel
-import com.github.se.eduverse.viewmodel.VideoViewModelFactory
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
@@ -74,8 +72,6 @@ class MainActivity : ComponentActivity() {
   private lateinit var auth: FirebaseAuth
   private var cameraPermissionGranted by mutableStateOf(false)
 
-  private lateinit var videoViewModel: VideoViewModel
-
   override fun onCreate(savedInstanceState: Bundle?) {
 
     super.onCreate(savedInstanceState)
@@ -87,10 +83,6 @@ class MainActivity : ComponentActivity() {
     }
 
     // Ajout du VideoRepository et du VideoViewModel
-    val videoRepository =
-        VideoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
-    val videoViewModelFactory = VideoViewModelFactory(videoRepository)
-    videoViewModel = ViewModelProvider(this, videoViewModelFactory)[VideoViewModel::class.java]
 
     // Gestion des permissions de la caméra
     val requestPermissionLauncher =
@@ -107,9 +99,7 @@ class MainActivity : ComponentActivity() {
 
     setContent {
       EduverseTheme {
-        Surface(modifier = Modifier.fillMaxSize()) {
-          EduverseApp(cameraPermissionGranted, videoViewModel)
-        }
+        Surface(modifier = Modifier.fillMaxSize()) { EduverseApp(cameraPermissionGranted) }
       }
     }
   }
@@ -117,7 +107,7 @@ class MainActivity : ComponentActivity() {
 
 @SuppressLint("ComposableDestinationInComposeScope")
 @Composable
-fun EduverseApp(cameraPermissionGranted: Boolean, videoViewModel: VideoViewModel) {
+fun EduverseApp(cameraPermissionGranted: Boolean) {
   val firestore = FirebaseFirestore.getInstance()
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -134,6 +124,8 @@ fun EduverseApp(cameraPermissionGranted: Boolean, videoViewModel: VideoViewModel
   val fileViewModel = FileViewModel(fileRepo)
   val photoRepo = PhotoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
   val photoViewModel = PhotoViewModel(photoRepo, fileRepo)
+  val videoRepo = VideoRepository(FirebaseFirestore.getInstance(), FirebaseStorage.getInstance())
+  val videoViewModel = VideoViewModel(videoRepo, fileRepo)
 
   val pubRepo = PublicationRepository(firestore)
   val publicationViewModel = PublicationViewModel(pubRepo)

--- a/app/src/main/java/com/github/se/eduverse/ui/Helper.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/Helper.kt
@@ -1,0 +1,87 @@
+package com.github.se.eduverse.ui
+
+import android.content.Context
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+import com.github.se.eduverse.model.Folder
+import com.github.se.eduverse.viewmodel.FolderViewModel
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+/**
+ * Create a bottom menu with the list of the folders of the active user
+ *
+ * @param context the context in which the dialog must be opened
+ * @param folderViewModel the folder view model of the app
+ * @param select the action to do when clicking on a folder
+ */
+fun showBottomMenu(context: Context, folderViewModel: FolderViewModel, select: (Folder) -> Unit) {
+  // Create the BottomSheetDialog
+  val bottomSheetDialog = BottomSheetDialog(context)
+
+  // Define a list of Folder objects
+  folderViewModel.getUserFolders()
+  val folders = folderViewModel.folders.value
+
+  // Set the inflated view as the content of the BottomSheetDialog
+  bottomSheetDialog.setContentView(
+      ComposeView(context).apply {
+        setContent {
+          Column(modifier = Modifier.padding(16.dp).fillMaxWidth().testTag("button_container")) {
+            folders.forEach { folder ->
+              Card(
+                  modifier =
+                      Modifier.padding(8.dp)
+                          .fillMaxWidth()
+                          .clickable {
+                            select(folder)
+                            bottomSheetDialog.dismiss()
+                          }
+                          .testTag("folder_button${folder.id}"),
+                  elevation = 4.dp) {
+                    Text(
+                        text = folder.name,
+                        modifier = Modifier.padding(16.dp),
+                        style = androidx.compose.material.MaterialTheme.typography.h6)
+                  }
+            }
+          }
+        }
+      })
+
+  // Show the dialog
+  bottomSheetDialog.show()
+
+  // Dismiss the dialog on lifecycle changes
+  if (context is LifecycleOwner) {
+    @Suppress("DEPRECATION")
+    val lifecycleObserver =
+        object : LifecycleObserver {
+          @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+          fun onStop() {
+            if (bottomSheetDialog.isShowing) {
+              bottomSheetDialog.dismiss()
+            }
+          }
+
+          @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+          fun onDestroy() {
+            // Remove observer to prevent memory leaks
+            (context as LifecycleOwner).lifecycle.removeObserver(this)
+          }
+        }
+
+    (context as LifecycleOwner).lifecycle.addObserver(lifecycleObserver)
+  }
+}

--- a/app/src/main/java/com/github/se/eduverse/ui/camera/nextScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/camera/nextScreen.kt
@@ -159,7 +159,27 @@ fun NextScreen(
         verticalArrangement = Arrangement.spacedBy(24.dp)) {
           StyledButton(
               text = " Add to folder", iconRes = R.drawable.add, testTag = "addToFolderButton") {
-                showBottomMenu(context, folderViewModel) { folder = it }
+                showBottomMenu(context, folderViewModel) {
+                  bitmap?.let { bmp ->
+                    val byteArray = imageBitmapToByteArray(bmp)
+                    val photo = Photo(ownerId, byteArray, path)
+                    photoViewModel.savePhoto(photo, it) { id, name, folder ->
+                      folderViewModel.createFileInFolder(id, name, folder)
+                    }
+                    navigationActions.goBack()
+                    navigationActions.goBack()
+                    navigationActions.goBack()
+                  }
+
+                  videoFile?.let { file ->
+                    val videoByteArray = file.readBytes()
+                    val video = Video(ownerId, videoByteArray, path.replace(".jpg", ".mp4"))
+                    videoViewModel.saveVideo(video)
+                    navigationActions.goBack()
+                    navigationActions.goBack()
+                    navigationActions.goBack()
+                  }
+                }
               }
           StyledButton(
               text = " More options",
@@ -179,9 +199,7 @@ fun NextScreen(
                 bitmap?.let { bmp ->
                   val byteArray = imageBitmapToByteArray(bmp)
                   val photo = Photo(ownerId, byteArray, path)
-                  photoViewModel.savePhoto(photo, folder) { id, name, folder ->
-                    folderViewModel.createFileInFolder(id, name, folder)
-                  }
+                  photoViewModel.savePhoto(photo)
                   navigationActions.goBack()
                   navigationActions.goBack()
                   navigationActions.goBack()

--- a/app/src/main/java/com/github/se/eduverse/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/gallery/GalleryScreen.kt
@@ -16,11 +16,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.eduverse.model.Photo
-import com.github.se.eduverse.ui.camera.showBottomMenu
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.showBottomMenu
 import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
 
@@ -156,4 +157,10 @@ fun downloadImage(imagePath: String) {
   // Cela pourrait impliquer d'utiliser une bibliothèque ou API pour manipuler des fichiers et
   // stocker des images localement
   Log.d("GalleryScreen", "Downloading image from: $imagePath")
+}
+
+@Composable
+@Preview
+fun PreviewDialog() {
+  ImageDialog(Photo("", byteArrayOf(0x01, 0x02)), {}, {}, {})
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/gallery/GalleryScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.eduverse.ui.screens
+package com.github.se.eduverse.ui.gallery
 
 import android.util.Log
 import androidx.compose.foundation.Image
@@ -13,26 +13,31 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.* // Material 3 API
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.eduverse.model.Photo
+import com.github.se.eduverse.ui.camera.showBottomMenu
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.viewmodel.FolderViewModel
 import com.github.se.eduverse.viewmodel.PhotoViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GalleryScreen(
     ownerId: String,
-    viewModel: PhotoViewModel,
+    photoViewModel: PhotoViewModel,
+    folderViewModel: FolderViewModel,
     navigationActions: NavigationActions // Paramètre pour les actions de navigation
 ) {
-  val photos by viewModel.photos.collectAsState()
+  val context = LocalContext.current
+  val photos by photoViewModel.photos.collectAsState()
   var selectedPhoto by remember { mutableStateOf<Photo?>(null) } // État pour l'image sélectionnée
 
   LaunchedEffect(ownerId) {
-    viewModel.getPhotosByOwner(ownerId) // Récupère les photos pour cet utilisateur
+    photoViewModel.getPhotosByOwner(ownerId) // Récupère les photos pour cet utilisateur
   }
 
   Scaffold(
@@ -82,6 +87,13 @@ fun GalleryScreen(
         onDownload = {
           // Appelle la fonction pour télécharger l'image
           downloadImage(photo.path ?: "unknown")
+        },
+        onAdd = {
+          showBottomMenu(context, folderViewModel) { folder ->
+            photoViewModel.makeFileFromPhoto(photo) {
+              folderViewModel.createFileInFolder(it, it, folder)
+            }
+          }
         })
   }
 }
@@ -97,7 +109,7 @@ fun PhotoItem(photo: Photo, modifier: Modifier = Modifier, onClick: () -> Unit) 
 }
 
 @Composable
-fun ImageDialog(photo: Photo, onDismiss: () -> Unit, onDownload: () -> Unit) {
+fun ImageDialog(photo: Photo, onDismiss: () -> Unit, onDownload: () -> Unit, onAdd: () -> Unit) {
   AlertDialog(
       onDismissRequest = { onDismiss() },
       text = {
@@ -123,13 +135,18 @@ fun ImageDialog(photo: Photo, onDismiss: () -> Unit, onDownload: () -> Unit) {
             }
       },
       dismissButton = {
-        IconButton(
-            onClick = { onDownload() },
-            modifier =
-                Modifier.testTag("DownloadButton") // Ajout du testTag pour le bouton Download
-            ) {
-              Icon(imageVector = Icons.Default.Download, contentDescription = "Download Image")
-            }
+        Row {
+          IconButton(
+              onClick = { onDownload() },
+              modifier =
+                  Modifier.testTag("DownloadButton") // Ajout du testTag pour le bouton Download
+              ) {
+                Icon(imageVector = Icons.Default.Download, contentDescription = "Download Image")
+              }
+          TextButton(onClick = { onAdd() }, modifier = Modifier.testTag("addToFolder")) {
+            Text("Add to folder")
+          }
+        }
       })
 }
 


### PR DESCRIPTION
This PR add the possibility to add photo and video inside folders.

This is possible from the `NextScreen`, the screen that appears when we take a picture and press "next". Upon clicking on the "Add to folder" button, a dialog appears on the bottom of the page, listing all existing folders. When clicking on one, the photo/video will be added to the folder. The button act like the save button, also saving into storage and leaving the camera.

![WhatsApp Image 2024-11-04 à 14 23 01_091a2b12](https://github.com/user-attachments/assets/bcb7d2a6-b778-4681-a8d2-f8a527ff2477)

It is now also possible to do the same thing from the gallery screen. When pressing to display a photo, there is a new button that allows to add it to a folder, by using the same bottom dialog.

![Capture d'écran 2024-11-06 113103](https://github.com/user-attachments/assets/9ef564bc-ea5d-41ff-ae0d-b17dc5b4c377)


The feature needed a few changes from the photoViewModel and video, but those were made to ensure compatiblity with former arguments.

All new content was tested, and test of modified part were upgraded when needed.