### PR TITLE
Add Settings Navigation to Profile Screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.eduverse.model.Profile
 import com.github.se.eduverse.model.Publication
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.viewmodel.ProfileUiState
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -177,5 +178,19 @@ class ProfileScreenTest {
     }
 
     composeTestRule.onNodeWithTag("profile_username").assertTextContains("TestUser")
+  }
+
+  @Test
+  fun whenSettingsButtonClicked_navigatesToSettings() {
+    val testProfile = Profile(id = "test", username = "TestUser")
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = fakeNavigationActions, viewModel = fakeViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("settings_button").assertExists()
+    composeTestRule.onNodeWithTag("settings_button").performClick()
+    assertTrue(fakeNavigationActions.lastNavigatedRoute == Screen.SETTING)
   }
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Article
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -35,6 +36,7 @@ import com.github.se.eduverse.model.Publication
 import com.github.se.eduverse.ui.navigation.BottomNavigationMenu
 import com.github.se.eduverse.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.viewmodel.ProfileUiState
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.google.firebase.auth.FirebaseAuth
@@ -78,6 +80,13 @@ fun ProfileScreen(
                   onClick = { navigationActions.goBack() },
                   modifier = Modifier.testTag("back_button")) {
                     Icon(Icons.Default.ArrowBack, "Back")
+                  }
+            },
+            actions = {
+              IconButton(
+                  onClick = { navigationActions.navigateTo(Screen.SETTING) },
+                  modifier = Modifier.testTag("settings_button")) {
+                    Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
                   }
             })
       },


### PR DESCRIPTION
## Overview
This PR adds a settings button to the profile screen's top bar, following Instagram's UI pattern, and implements navigation to the settings screen.

## Key Features
* Settings button in top app bar
* Navigation to settings screen
* Integration with existing navigation system
* Material Design icon usage

## Technical Implementation
* Added actions parameter to TopAppBar
* Used Material Icons for consistency
* Integrated with existing NavigationActions
* Added test tags for UI testing

## Testing
* New UI test for settings button functionality
* Verifies:
 * Button rendering
 * Navigation behavior
 * Integration with navigation actions
* Maintains existing test coverage

## Testing Instructions
1. Run the app and navigate to profile screen
2. Verify settings icon appears in top right
3. Click settings icon
4. Confirm navigation to settings screen

## Screenshots
![image](https://github.com/user-attachments/assets/f9e720aa-1cd5-4319-bd73-910412703a90)

## Notes
* Follows Instagram's UI pattern
* Uses existing navigation infrastructure
* All tests passing

Let me know if any adjustments are needed.