### PR TITLE
Add User Profile View and Improve Search Functionality

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
@@ -196,8 +196,6 @@ class ProfileScreenTest {
         .assertTextContains("No publications yet")
   }
 
-
-
   @Test
   fun whenProfileImageClicked_exists() {
     val testProfile = Profile(id = "test", username = "TestUser")

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/profile/ProfileScreenTest.kt
@@ -196,15 +196,7 @@ class ProfileScreenTest {
         .assertTextContains("No publications yet")
   }
 
-  @Test
-  fun whenBackButtonClicked_navigatesBack() {
-    composeTestRule.setContent {
-      ProfileScreen(navigationActions = fakeNavigationActions, viewModel = fakeViewModel)
-    }
 
-    composeTestRule.onNodeWithTag("back_button").performClick()
-    assertTrue(fakeNavigationActions.backClicked)
-  }
 
   @Test
   fun whenProfileImageClicked_exists() {

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.se.eduverse.model.Profile
 import com.github.se.eduverse.repository.ProfileRepository
+import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,176 +15,166 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 class SearchProfileScreenTest {
-  @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
-  @Mock private lateinit var mockRepository: ProfileRepository
+    @Mock
+    private lateinit var mockRepository: ProfileRepository
+    @Mock
+    private lateinit var mockNavigationActions: NavigationActions
 
-  private lateinit var viewModel: TestProfileViewModel
-  private val searchStateFlow = MutableStateFlow<SearchProfileState>(SearchProfileState.Idle)
+    private lateinit var viewModel: TestProfileViewModel
+    private val searchStateFlow = MutableStateFlow<SearchProfileState>(SearchProfileState.Idle)
 
-  private val testProfiles =
-      listOf(
-          Profile(
-              id = "1",
-              username = "testUser1",
-              followers = 100,
-              following = 50,
-              profileImageUrl = "test_url_1"),
-          Profile(
-              id = "2",
-              username = "testUser2",
-              followers = 200,
-              following = 150,
-              profileImageUrl = "test_url_2"))
+    private val testProfiles = listOf(
+        Profile(
+            id = "1",
+            username = "testUser1",
+            followers = 100,
+            following = 50,
+            profileImageUrl = "test_url_1"
+        ),
+        Profile(
+            id = "2",
+            username = "testUser2",
+            followers = 200,
+            following = 150,
+            profileImageUrl = "test_url_2"
+        )
+    )
 
-  private class TestProfileViewModel(
-      repository: ProfileRepository,
-      private val testSearchState: MutableStateFlow<SearchProfileState>
-  ) : ProfileViewModel(repository) {
-    override val searchState: StateFlow<SearchProfileState> = testSearchState
-  }
-
-  @Before
-  fun setup() {
-    MockitoAnnotations.openMocks(this)
-    mockRepository = mock()
-    viewModel = TestProfileViewModel(mockRepository, searchStateFlow)
-  }
-
-  @Test
-  fun searchField_isDisplayed() {
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).assertExists().assertIsDisplayed()
-  }
-
-  @Test
-  fun idleState_showsSearchPrompt() {
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    composeTestRule
-        .onNodeWithTag(TAG_IDLE_MESSAGE)
-        .assertExists()
-        .assertIsDisplayed()
-        .onChildren()
-        .filterToOne(hasText("Search for other users"))
-        .assertExists()
-  }
-
-  @Test
-  fun loadingState_showsProgressIndicator() {
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    searchStateFlow.value = SearchProfileState.Loading
-
-    composeTestRule.onNodeWithTag(TAG_LOADING_INDICATOR).assertExists().assertIsDisplayed()
-  }
-
-  @Test
-  fun successState_withResults_showsProfiles() {
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    searchStateFlow.value = SearchProfileState.Success(testProfiles)
-
-    // Check profile list exists
-    composeTestRule.onNodeWithTag(TAG_PROFILE_LIST).assertExists().assertIsDisplayed()
-
-    // Check profile item exists
-    composeTestRule.onNodeWithTag("${TAG_PROFILE_ITEM}_1").assertExists().assertIsDisplayed()
-
-    // Check username with unmerged tree
-    composeTestRule
-        .onNodeWithTag("${TAG_PROFILE_USERNAME}_1", useUnmergedTree = true)
-        .assertExists()
-        .assertIsDisplayed()
-
-    // Check stats with unmerged tree
-    composeTestRule
-        .onNodeWithTag("${TAG_PROFILE_STATS}_1", useUnmergedTree = true)
-        .assertExists()
-        .assertIsDisplayed()
-        .onChildren()
-        .filterToOne(hasText("100 followers"))
-        .assertExists()
-  }
-
-  @Test
-  fun successState_withEmptyResults_showsNoProfilesFound() {
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("nonexistent")
-
-    searchStateFlow.value = SearchProfileState.Success(emptyList())
-
-    composeTestRule
-        .onNodeWithTag(TAG_NO_RESULTS)
-        .assertExists()
-        .assertIsDisplayed()
-        .onChildren()
-        .filterToOne(hasText("No profiles found"))
-        .assertExists()
-  }
-
-  @Test
-  fun errorState_showsErrorMessage() {
-    val errorMessage = "Test error message"
-
-    composeTestRule.setContent { SearchProfileScreen(viewModel = viewModel, onProfileClick = {}) }
-
-    searchStateFlow.value = SearchProfileState.Error(errorMessage)
-
-    composeTestRule
-        .onNodeWithTag(TAG_ERROR_MESSAGE)
-        .assertExists()
-        .assertIsDisplayed()
-        .onChildren()
-        .filterToOne(hasText(errorMessage))
-        .assertExists()
-  }
-
-  @Test
-  fun profileClick_triggersCallback() {
-    var clickedProfileId = ""
-
-    composeTestRule.setContent {
-      SearchProfileScreen(viewModel = viewModel, onProfileClick = { clickedProfileId = it })
+    private class TestProfileViewModel(
+        repository: ProfileRepository,
+        private val testSearchState: MutableStateFlow<SearchProfileState>
+    ) : ProfileViewModel(repository) {
+        override val searchState: StateFlow<SearchProfileState> = testSearchState
     }
 
-    searchStateFlow.value = SearchProfileState.Success(testProfiles)
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        mockRepository = mock()
+        mockNavigationActions = mock()
+        viewModel = TestProfileViewModel(mockRepository, searchStateFlow)
+    }
 
-    composeTestRule.onNodeWithTag("${TAG_PROFILE_ITEM}_1").performClick()
-
-    assert(clickedProfileId == "1")
-  }
-
-  @Test
-  fun searchInput_triggersViewModelSearch() {
-    // Create a test implementation of ProfileViewModel
-    val testViewModel =
-        object : ProfileViewModel(mockRepository) {
-          override fun searchProfiles(query: String) {
-            // Update the search state to Loading when search is triggered
-            searchStateFlow.value = SearchProfileState.Loading
-          }
+    @Test
+    fun topAppBar_isDisplayed() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
         }
 
-    composeTestRule.setContent {
-      SearchProfileScreen(viewModel = testViewModel, onProfileClick = {})
+        composeTestRule.onNodeWithText("Search Users").assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag("search_back_button").assertExists().assertIsDisplayed()
     }
 
-    composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("test")
+    @Test
+    fun backButton_triggersNavigation() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
+        }
 
-    // Wait for debounce
-    composeTestRule.mainClock.advanceTimeBy(500L)
-    composeTestRule.waitForIdle()
-
-    // Verify the state changed to Loading
-    assert(searchStateFlow.value is SearchProfileState.Loading) {
-      "Search state should have changed to Loading, but was ${searchStateFlow.value}"
+        composeTestRule.onNodeWithTag("search_back_button").performClick()
+        verify(mockNavigationActions).goBack()
     }
-  }
+
+    @Test
+    fun searchField_isDisplayed() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
+        }
+
+        composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).assertExists().assertIsDisplayed()
+    }
+
+    @Test
+    fun idleState_showsSearchPrompt() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
+        }
+
+        composeTestRule.onNodeWithTag(TAG_IDLE_MESSAGE)
+            .assertExists()
+            .assertIsDisplayed()
+            .onChildren()
+            .filterToOne(hasText("Search for other users"))
+            .assertExists()
+    }
+
+    @Test
+    fun loadingState_showsProgressIndicator() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
+        }
+
+        searchStateFlow.value = SearchProfileState.Loading
+        composeTestRule.onNodeWithTag(TAG_LOADING_INDICATOR).assertExists().assertIsDisplayed()
+    }
+
+    @Test
+    fun successState_withResults_showsProfiles() {
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = viewModel
+            )
+        }
+
+        searchStateFlow.value = SearchProfileState.Success(testProfiles)
+
+        composeTestRule.onNodeWithTag(TAG_PROFILE_LIST).assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag("${TAG_PROFILE_ITEM}_1").assertExists().assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("${TAG_PROFILE_USERNAME}_1", useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("${TAG_PROFILE_STATS}_1", useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+            .onChildren()
+            .filterToOne(hasText("100 followers"))
+            .assertExists()
+    }
+
+    @Test
+    fun searchInput_convertsToLowerCase() {
+        var searchQuery = ""
+        val testViewModel = object : ProfileViewModel(mockRepository) {
+            override fun searchProfiles(query: String) {
+                searchQuery = query
+            }
+        }
+
+        composeTestRule.setContent {
+            SearchProfileScreen(
+                navigationActions = mockNavigationActions,
+                viewModel = testViewModel
+            )
+        }
+
+        composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("TestQuery")
+        assert(searchQuery == "testquery") { "Search query should be converted to lowercase" }
+    }
+
 }
 
 class ProfileSearchItemTest {

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
@@ -18,163 +18,140 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 class SearchProfileScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Mock
-    private lateinit var mockRepository: ProfileRepository
-    @Mock
-    private lateinit var mockNavigationActions: NavigationActions
+  @Mock private lateinit var mockRepository: ProfileRepository
+  @Mock private lateinit var mockNavigationActions: NavigationActions
 
-    private lateinit var viewModel: TestProfileViewModel
-    private val searchStateFlow = MutableStateFlow<SearchProfileState>(SearchProfileState.Idle)
+  private lateinit var viewModel: TestProfileViewModel
+  private val searchStateFlow = MutableStateFlow<SearchProfileState>(SearchProfileState.Idle)
 
-    private val testProfiles = listOf(
-        Profile(
-            id = "1",
-            username = "testUser1",
-            followers = 100,
-            following = 50,
-            profileImageUrl = "test_url_1"
-        ),
-        Profile(
-            id = "2",
-            username = "testUser2",
-            followers = 200,
-            following = 150,
-            profileImageUrl = "test_url_2"
-        )
-    )
+  private val testProfiles =
+      listOf(
+          Profile(
+              id = "1",
+              username = "testUser1",
+              followers = 100,
+              following = 50,
+              profileImageUrl = "test_url_1"),
+          Profile(
+              id = "2",
+              username = "testUser2",
+              followers = 200,
+              following = 150,
+              profileImageUrl = "test_url_2"))
 
-    private class TestProfileViewModel(
-        repository: ProfileRepository,
-        private val testSearchState: MutableStateFlow<SearchProfileState>
-    ) : ProfileViewModel(repository) {
-        override val searchState: StateFlow<SearchProfileState> = testSearchState
+  private class TestProfileViewModel(
+      repository: ProfileRepository,
+      private val testSearchState: MutableStateFlow<SearchProfileState>
+  ) : ProfileViewModel(repository) {
+    override val searchState: StateFlow<SearchProfileState> = testSearchState
+  }
+
+  @Before
+  fun setup() {
+    MockitoAnnotations.openMocks(this)
+    mockRepository = mock()
+    mockNavigationActions = mock()
+    viewModel = TestProfileViewModel(mockRepository, searchStateFlow)
+  }
+
+  @Test
+  fun topAppBar_isDisplayed() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
     }
 
-    @Before
-    fun setup() {
-        MockitoAnnotations.openMocks(this)
-        mockRepository = mock()
-        mockNavigationActions = mock()
-        viewModel = TestProfileViewModel(mockRepository, searchStateFlow)
+    composeTestRule.onNodeWithText("Search Users").assertExists().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("search_back_button").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun backButton_triggersNavigation() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
     }
 
-    @Test
-    fun topAppBar_isDisplayed() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
+    composeTestRule.onNodeWithTag("search_back_button").performClick()
+    verify(mockNavigationActions).goBack()
+  }
+
+  @Test
+  fun searchField_isDisplayed() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
+    }
+
+    composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun idleState_showsSearchPrompt() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
+    }
+
+    composeTestRule
+        .onNodeWithTag(TAG_IDLE_MESSAGE)
+        .assertExists()
+        .assertIsDisplayed()
+        .onChildren()
+        .filterToOne(hasText("Search for other users"))
+        .assertExists()
+  }
+
+  @Test
+  fun loadingState_showsProgressIndicator() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
+    }
+
+    searchStateFlow.value = SearchProfileState.Loading
+    composeTestRule.onNodeWithTag(TAG_LOADING_INDICATOR).assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun successState_withResults_showsProfiles() {
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = viewModel)
+    }
+
+    searchStateFlow.value = SearchProfileState.Success(testProfiles)
+
+    composeTestRule.onNodeWithTag(TAG_PROFILE_LIST).assertExists().assertIsDisplayed()
+    composeTestRule.onNodeWithTag("${TAG_PROFILE_ITEM}_1").assertExists().assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag("${TAG_PROFILE_USERNAME}_1", useUnmergedTree = true)
+        .assertExists()
+        .assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag("${TAG_PROFILE_STATS}_1", useUnmergedTree = true)
+        .assertExists()
+        .assertIsDisplayed()
+        .onChildren()
+        .filterToOne(hasText("100 followers"))
+        .assertExists()
+  }
+
+  @Test
+  fun searchInput_convertsToLowerCase() {
+    var searchQuery = ""
+    val testViewModel =
+        object : ProfileViewModel(mockRepository) {
+          override fun searchProfiles(query: String) {
+            searchQuery = query
+          }
         }
 
-        composeTestRule.onNodeWithText("Search Users").assertExists().assertIsDisplayed()
-        composeTestRule.onNodeWithTag("search_back_button").assertExists().assertIsDisplayed()
+    composeTestRule.setContent {
+      SearchProfileScreen(navigationActions = mockNavigationActions, viewModel = testViewModel)
     }
 
-    @Test
-    fun backButton_triggersNavigation() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
-        }
-
-        composeTestRule.onNodeWithTag("search_back_button").performClick()
-        verify(mockNavigationActions).goBack()
-    }
-
-    @Test
-    fun searchField_isDisplayed() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
-        }
-
-        composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).assertExists().assertIsDisplayed()
-    }
-
-    @Test
-    fun idleState_showsSearchPrompt() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
-        }
-
-        composeTestRule.onNodeWithTag(TAG_IDLE_MESSAGE)
-            .assertExists()
-            .assertIsDisplayed()
-            .onChildren()
-            .filterToOne(hasText("Search for other users"))
-            .assertExists()
-    }
-
-    @Test
-    fun loadingState_showsProgressIndicator() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
-        }
-
-        searchStateFlow.value = SearchProfileState.Loading
-        composeTestRule.onNodeWithTag(TAG_LOADING_INDICATOR).assertExists().assertIsDisplayed()
-    }
-
-    @Test
-    fun successState_withResults_showsProfiles() {
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = viewModel
-            )
-        }
-
-        searchStateFlow.value = SearchProfileState.Success(testProfiles)
-
-        composeTestRule.onNodeWithTag(TAG_PROFILE_LIST).assertExists().assertIsDisplayed()
-        composeTestRule.onNodeWithTag("${TAG_PROFILE_ITEM}_1").assertExists().assertIsDisplayed()
-
-        composeTestRule.onNodeWithTag("${TAG_PROFILE_USERNAME}_1", useUnmergedTree = true)
-            .assertExists()
-            .assertIsDisplayed()
-
-        composeTestRule.onNodeWithTag("${TAG_PROFILE_STATS}_1", useUnmergedTree = true)
-            .assertExists()
-            .assertIsDisplayed()
-            .onChildren()
-            .filterToOne(hasText("100 followers"))
-            .assertExists()
-    }
-
-    @Test
-    fun searchInput_convertsToLowerCase() {
-        var searchQuery = ""
-        val testViewModel = object : ProfileViewModel(mockRepository) {
-            override fun searchProfiles(query: String) {
-                searchQuery = query
-            }
-        }
-
-        composeTestRule.setContent {
-            SearchProfileScreen(
-                navigationActions = mockNavigationActions,
-                viewModel = testViewModel
-            )
-        }
-
-        composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("TestQuery")
-        assert(searchQuery == "testquery") { "Search query should be converted to lowercase" }
-    }
-
+    composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("TestQuery")
+    assert(searchQuery == "testquery") { "Search query should be converted to lowercase" }
+  }
 }
 
 class ProfileSearchItemTest {

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/search/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/search/UserProfileScreenTest.kt
@@ -18,266 +18,226 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
 class UserProfileScreenTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private lateinit var fakeViewModel: FakeProfileViewModel
-    private lateinit var fakeNavigationActions: FakeNavigationActions
-    private val testUserId = "test_user_id"
+  private lateinit var fakeViewModel: FakeProfileViewModel
+  private lateinit var fakeNavigationActions: FakeNavigationActions
+  private val testUserId = "test_user_id"
 
-    @Before
-    fun setup() {
-        fakeViewModel = FakeProfileViewModel()
-        fakeNavigationActions = FakeNavigationActions()
+  @Before
+  fun setup() {
+    fakeViewModel = FakeProfileViewModel()
+    fakeNavigationActions = FakeNavigationActions()
+  }
+
+  class FakeProfileViewModel : ProfileViewModel(mock()) {
+    private val _profileState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)
+    override val profileState: StateFlow<ProfileUiState> = _profileState.asStateFlow()
+
+    private val _likedPublications = MutableStateFlow<List<Publication>>(emptyList())
+    override val likedPublications: StateFlow<List<Publication>> = _likedPublications.asStateFlow()
+
+    fun setState(state: ProfileUiState) {
+      _profileState.value = state
     }
 
-    class FakeProfileViewModel : ProfileViewModel(mock()) {
-        private val _profileState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)
-        override val profileState: StateFlow<ProfileUiState> = _profileState.asStateFlow()
+    fun setLikedPublications(publications: List<Publication>) {
+      _likedPublications.value = publications
+    }
+  }
 
-        private val _likedPublications = MutableStateFlow<List<Publication>>(emptyList())
-        override val likedPublications: StateFlow<List<Publication>> = _likedPublications.asStateFlow()
+  class FakeNavigationActions : NavigationActions(mock()) {
+    var backClicked = false
+      private set
 
-        fun setState(state: ProfileUiState) {
-            _profileState.value = state
-        }
+    override fun goBack() {
+      backClicked = true
+    }
+  }
 
-        fun setLikedPublications(publications: List<Publication>) {
-            _likedPublications.value = publications
-        }
+  @Test
+  fun whenScreenLoads_showsLoadingState() {
+    fakeViewModel.setState(ProfileUiState.Loading)
+
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    class FakeNavigationActions : NavigationActions(mock()) {
-        var backClicked = false
-            private set
+    composeTestRule.onNodeWithTag("loading_indicator").assertExists()
+  }
 
-        override fun goBack() {
-            backClicked = true
-        }
-    }
-
-    @Test
-    fun whenScreenLoads_showsLoadingState() {
-        fakeViewModel.setState(ProfileUiState.Loading)
-
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("loading_indicator").assertExists()
-    }
-
-    @Test
-    fun whenProfileLoaded_showsProfileContent() {
-        val testProfile = Profile(
+  @Test
+  fun whenProfileLoaded_showsProfileContent() {
+    val testProfile =
+        Profile(
             id = testUserId,
             username = "TestUser",
             followers = 100,
             following = 200,
-            publications = listOf(Publication(id = "pub1", title = "Test Publication"))
-        )
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+            publications = listOf(Publication(id = "pub1", title = "Test Publication")))
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("user_profile_image_container").assertExists()
-        composeTestRule.onNodeWithTag("stats_row").assertExists()
-        composeTestRule.onNodeWithTag("stat_count_Followers").assertTextContains("100")
-        composeTestRule.onNodeWithTag("stat_count_Following").assertTextContains("200")
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenError_showsErrorMessage() {
-        fakeViewModel.setState(ProfileUiState.Error("Test error"))
+    composeTestRule.onNodeWithTag("user_profile_image_container").assertExists()
+    composeTestRule.onNodeWithTag("stats_row").assertExists()
+    composeTestRule.onNodeWithTag("stat_count_Followers").assertTextContains("100")
+    composeTestRule.onNodeWithTag("stat_count_Following").assertTextContains("200")
+  }
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
+  @Test
+  fun whenError_showsErrorMessage() {
+    fakeViewModel.setState(ProfileUiState.Error("Test error"))
 
-        composeTestRule.onNodeWithTag("error_message").assertExists().assertTextContains("Test error")
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenTabsClicked_switchesContent() {
-        val testProfile = Profile(
+    composeTestRule.onNodeWithTag("error_message").assertExists().assertTextContains("Test error")
+  }
+
+  @Test
+  fun whenTabsClicked_switchesContent() {
+    val testProfile =
+        Profile(
             id = testUserId,
             username = "TestUser",
-            publications = listOf(Publication(id = "pub1", title = "Test Publication"))
-        )
-        val likedPublications = listOf(
-            Publication(id = "fav1", title = "Favorite Publication", userId = "testUser")
-        )
+            publications = listOf(Publication(id = "pub1", title = "Test Publication")))
+    val likedPublications =
+        listOf(Publication(id = "fav1", title = "Favorite Publication", userId = "testUser"))
 
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
-        fakeViewModel.setLikedPublications(likedPublications)
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
+    fakeViewModel.setLikedPublications(likedPublications)
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("publications_tab").performClick()
-        composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
-
-        composeTestRule.onNodeWithTag("favorites_tab").performClick()
-        composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenBackButtonClicked_callsNavigationGoBack() {
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
+    composeTestRule.onNodeWithTag("publications_tab").performClick()
+    composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
 
-        composeTestRule.onNodeWithTag("back_button").performClick()
-        assert(fakeNavigationActions.backClicked)
+    composeTestRule.onNodeWithTag("favorites_tab").performClick()
+    composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+  }
+
+  @Test
+  fun whenBackButtonClicked_callsNavigationGoBack() {
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenNoPublications_showsEmptyState() {
-        val testProfile = Profile(
+    composeTestRule.onNodeWithTag("back_button").performClick()
+    assert(fakeNavigationActions.backClicked)
+  }
+
+  @Test
+  fun whenNoPublications_showsEmptyState() {
+    val testProfile =
+        Profile(
             id = testUserId,
             username = "TestUser",
             publications = emptyList(),
-            favoritePublications = emptyList()
-        )
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+            favoritePublications = emptyList())
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("empty_publications_text")
-            .assertExists()
-            .assertTextContains("No publications yet")
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun verifyTopBarContent() {
-        val testProfile = Profile(id = testUserId, username = "TestUser")
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+    composeTestRule
+        .onNodeWithTag("empty_publications_text")
+        .assertExists()
+        .assertTextContains("No publications yet")
+  }
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
+  @Test
+  fun verifyTopBarContent() {
+    val testProfile = Profile(id = testUserId, username = "TestUser")
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
 
-        composeTestRule.onNodeWithTag("user_profile_username").assertTextContains("TestUser")
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenVideoPublication_showsPlayIcon() {
-        val videoPublication = Publication(
+    composeTestRule.onNodeWithTag("user_profile_username").assertTextContains("TestUser")
+  }
+
+  @Test
+  fun whenVideoPublication_showsPlayIcon() {
+    val videoPublication =
+        Publication(
             id = "video1",
             title = "Test Video",
             mediaType = MediaType.VIDEO,
             thumbnailUrl = "https://example.com/thumb.jpg",
-            mediaUrl = "https://example.com/video.mp4"
-        )
-        val testProfile = Profile(
-            id = testUserId,
-            username = "TestUser",
-            publications = listOf(videoPublication)
-        )
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+            mediaUrl = "https://example.com/video.mp4")
+    val testProfile =
+        Profile(id = testUserId, username = "TestUser", publications = listOf(videoPublication))
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("video_play_icon_video1", useUnmergedTree = true).assertExists()
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenPublicationClicked_showsDetailDialog() {
-        val publication = Publication(
+    composeTestRule.onNodeWithTag("video_play_icon_video1", useUnmergedTree = true).assertExists()
+  }
+
+  @Test
+  fun whenPublicationClicked_showsDetailDialog() {
+    val publication =
+        Publication(
             id = "pub1",
             title = "Test Publication",
             mediaType = MediaType.PHOTO,
             thumbnailUrl = "https://example.com/thumb.jpg",
-            mediaUrl = "https://example.com/photo.jpg"
-        )
-        val testProfile = Profile(
-            id = testUserId,
-            username = "TestUser",
-            publications = listOf(publication)
-        )
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+            mediaUrl = "https://example.com/photo.jpg")
+    val testProfile =
+        Profile(id = testUserId, username = "TestUser", publications = listOf(publication))
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
-
-        composeTestRule.onNodeWithTag("publication_item_pub1").performClick()
-        composeTestRule.onNodeWithText("Test Publication").assertExists()
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
 
-    @Test
-    fun whenSwitchingTabs_maintainsCorrectPublications() {
-        val publication = Publication(id = "pub1", title = "Regular Publication", userId = testUserId)
-        val likedPublication = Publication(id = "fav1", title = "Favorite Publication", userId = testUserId)
+    composeTestRule.onNodeWithTag("publication_item_pub1").performClick()
+    composeTestRule.onNodeWithText("Test Publication").assertExists()
+  }
 
-        val testProfile = Profile(
-            id = testUserId,
-            username = "TestUser",
-            publications = listOf(publication)
-        )
-        fakeViewModel.setState(ProfileUiState.Success(testProfile))
-        fakeViewModel.setLikedPublications(listOf(likedPublication))
+  @Test
+  fun whenSwitchingTabs_maintainsCorrectPublications() {
+    val publication = Publication(id = "pub1", title = "Regular Publication", userId = testUserId)
+    val likedPublication =
+        Publication(id = "fav1", title = "Favorite Publication", userId = testUserId)
 
-        composeTestRule.setContent {
-            UserProfileScreen(
-                navigationActions = fakeNavigationActions,
-                viewModel = fakeViewModel,
-                userId = testUserId
-            )
-        }
+    val testProfile =
+        Profile(id = testUserId, username = "TestUser", publications = listOf(publication))
+    fakeViewModel.setState(ProfileUiState.Success(testProfile))
+    fakeViewModel.setLikedPublications(listOf(likedPublication))
 
-        composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
-        composeTestRule.onNodeWithTag("publication_item_fav1").assertDoesNotExist()
-
-        composeTestRule.onNodeWithTag("favorites_tab").performClick()
-        composeTestRule.onNodeWithTag("publication_item_pub1").assertDoesNotExist()
-        composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+    composeTestRule.setContent {
+      UserProfileScreen(
+          navigationActions = fakeNavigationActions, viewModel = fakeViewModel, userId = testUserId)
     }
+
+    composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
+    composeTestRule.onNodeWithTag("publication_item_fav1").assertDoesNotExist()
+
+    composeTestRule.onNodeWithTag("favorites_tab").performClick()
+    composeTestRule.onNodeWithTag("publication_item_pub1").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+  }
 }

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/search/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/search/UserProfileScreenTest.kt
@@ -1,0 +1,283 @@
+package com.github.se.eduverse.ui.search
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.model.MediaType
+import com.github.se.eduverse.model.Profile
+import com.github.se.eduverse.model.Publication
+import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.viewmodel.ProfileUiState
+import com.github.se.eduverse.viewmodel.ProfileViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class UserProfileScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var fakeViewModel: FakeProfileViewModel
+    private lateinit var fakeNavigationActions: FakeNavigationActions
+    private val testUserId = "test_user_id"
+
+    @Before
+    fun setup() {
+        fakeViewModel = FakeProfileViewModel()
+        fakeNavigationActions = FakeNavigationActions()
+    }
+
+    class FakeProfileViewModel : ProfileViewModel(mock()) {
+        private val _profileState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)
+        override val profileState: StateFlow<ProfileUiState> = _profileState.asStateFlow()
+
+        private val _likedPublications = MutableStateFlow<List<Publication>>(emptyList())
+        override val likedPublications: StateFlow<List<Publication>> = _likedPublications.asStateFlow()
+
+        fun setState(state: ProfileUiState) {
+            _profileState.value = state
+        }
+
+        fun setLikedPublications(publications: List<Publication>) {
+            _likedPublications.value = publications
+        }
+    }
+
+    class FakeNavigationActions : NavigationActions(mock()) {
+        var backClicked = false
+            private set
+
+        override fun goBack() {
+            backClicked = true
+        }
+    }
+
+    @Test
+    fun whenScreenLoads_showsLoadingState() {
+        fakeViewModel.setState(ProfileUiState.Loading)
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("loading_indicator").assertExists()
+    }
+
+    @Test
+    fun whenProfileLoaded_showsProfileContent() {
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            followers = 100,
+            following = 200,
+            publications = listOf(Publication(id = "pub1", title = "Test Publication"))
+        )
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("user_profile_image_container").assertExists()
+        composeTestRule.onNodeWithTag("stats_row").assertExists()
+        composeTestRule.onNodeWithTag("stat_count_Followers").assertTextContains("100")
+        composeTestRule.onNodeWithTag("stat_count_Following").assertTextContains("200")
+    }
+
+    @Test
+    fun whenError_showsErrorMessage() {
+        fakeViewModel.setState(ProfileUiState.Error("Test error"))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("error_message").assertExists().assertTextContains("Test error")
+    }
+
+    @Test
+    fun whenTabsClicked_switchesContent() {
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            publications = listOf(Publication(id = "pub1", title = "Test Publication"))
+        )
+        val likedPublications = listOf(
+            Publication(id = "fav1", title = "Favorite Publication", userId = "testUser")
+        )
+
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+        fakeViewModel.setLikedPublications(likedPublications)
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("publications_tab").performClick()
+        composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
+
+        composeTestRule.onNodeWithTag("favorites_tab").performClick()
+        composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+    }
+
+    @Test
+    fun whenBackButtonClicked_callsNavigationGoBack() {
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("back_button").performClick()
+        assert(fakeNavigationActions.backClicked)
+    }
+
+    @Test
+    fun whenNoPublications_showsEmptyState() {
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            publications = emptyList(),
+            favoritePublications = emptyList()
+        )
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("empty_publications_text")
+            .assertExists()
+            .assertTextContains("No publications yet")
+    }
+
+    @Test
+    fun verifyTopBarContent() {
+        val testProfile = Profile(id = testUserId, username = "TestUser")
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("user_profile_username").assertTextContains("TestUser")
+    }
+
+    @Test
+    fun whenVideoPublication_showsPlayIcon() {
+        val videoPublication = Publication(
+            id = "video1",
+            title = "Test Video",
+            mediaType = MediaType.VIDEO,
+            thumbnailUrl = "https://example.com/thumb.jpg",
+            mediaUrl = "https://example.com/video.mp4"
+        )
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            publications = listOf(videoPublication)
+        )
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("video_play_icon_video1", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun whenPublicationClicked_showsDetailDialog() {
+        val publication = Publication(
+            id = "pub1",
+            title = "Test Publication",
+            mediaType = MediaType.PHOTO,
+            thumbnailUrl = "https://example.com/thumb.jpg",
+            mediaUrl = "https://example.com/photo.jpg"
+        )
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            publications = listOf(publication)
+        )
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("publication_item_pub1").performClick()
+        composeTestRule.onNodeWithText("Test Publication").assertExists()
+    }
+
+    @Test
+    fun whenSwitchingTabs_maintainsCorrectPublications() {
+        val publication = Publication(id = "pub1", title = "Regular Publication", userId = testUserId)
+        val likedPublication = Publication(id = "fav1", title = "Favorite Publication", userId = testUserId)
+
+        val testProfile = Profile(
+            id = testUserId,
+            username = "TestUser",
+            publications = listOf(publication)
+        )
+        fakeViewModel.setState(ProfileUiState.Success(testProfile))
+        fakeViewModel.setLikedPublications(listOf(likedPublication))
+
+        composeTestRule.setContent {
+            UserProfileScreen(
+                navigationActions = fakeNavigationActions,
+                viewModel = fakeViewModel,
+                userId = testUserId
+            )
+        }
+
+        composeTestRule.onNodeWithTag("publication_item_pub1").assertExists()
+        composeTestRule.onNodeWithTag("publication_item_fav1").assertDoesNotExist()
+
+        composeTestRule.onNodeWithTag("favorites_tab").performClick()
+        composeTestRule.onNodeWithTag("publication_item_pub1").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("publication_item_fav1").assertExists()
+    }
+}

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -154,26 +154,20 @@ fun EduverseApp(cameraPermissionGranted: Boolean) {
       composable(Screen.DASHBOARD) { DashboardScreen(navigationActions, dashboardViewModel) }
       composable(Screen.PDF_CONVERTER) { PdfConverterScreen(navigationActions) }
       composable(Screen.SEARCH) {
-        SearchProfileScreen(navigationActions,viewModel = profileViewModel)
+        SearchProfileScreen(navigationActions, viewModel = profileViewModel)
       }
-
     }
 
-      composable(
-          route = Screen.USER_PROFILE.route,
-          arguments = listOf(
-              navArgument("userId") { type = NavType.StringType }
-          )
-      ) { backStackEntry ->
-          val userId = backStackEntry.arguments?.getString("userId")
-              ?: return@composable // Handle missing userId
+    composable(
+        route = Screen.USER_PROFILE.route,
+        arguments = listOf(navArgument("userId") { type = NavType.StringType })) { backStackEntry ->
+          val userId =
+              backStackEntry.arguments?.getString("userId")
+                  ?: return@composable // Handle missing userId
 
           UserProfileScreen(
-              navigationActions = navigationActions,
-              viewModel = profileViewModel,
-              userId = userId
-          )
-      }
+              navigationActions = navigationActions, viewModel = profileViewModel, userId = userId)
+        }
 
     navigation(
         startDestination = Screen.VIDEOS,

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -51,6 +51,7 @@ import com.github.se.eduverse.ui.navigation.Route
 import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.ui.profile.ProfileScreen
 import com.github.se.eduverse.ui.search.SearchProfileScreen
+import com.github.se.eduverse.ui.search.UserProfileScreen
 import com.github.se.eduverse.ui.setting.SettingsScreen
 import com.github.se.eduverse.ui.theme.EduverseTheme
 import com.github.se.eduverse.viewmodel.DashboardViewModel
@@ -153,9 +154,26 @@ fun EduverseApp(cameraPermissionGranted: Boolean) {
       composable(Screen.DASHBOARD) { DashboardScreen(navigationActions, dashboardViewModel) }
       composable(Screen.PDF_CONVERTER) { PdfConverterScreen(navigationActions) }
       composable(Screen.SEARCH) {
-        SearchProfileScreen(viewModel = profileViewModel, onProfileClick = {})
+        SearchProfileScreen(navigationActions,viewModel = profileViewModel)
       }
+
     }
+
+      composable(
+          route = Screen.USER_PROFILE.route,
+          arguments = listOf(
+              navArgument("userId") { type = NavType.StringType }
+          )
+      ) { backStackEntry ->
+          val userId = backStackEntry.arguments?.getString("userId")
+              ?: return@composable // Handle missing userId
+
+          UserProfileScreen(
+              navigationActions = navigationActions,
+              viewModel = profileViewModel,
+              userId = userId
+          )
+      }
 
     navigation(
         startDestination = Screen.VIDEOS,

--- a/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
@@ -169,17 +169,15 @@ class ProfileRepositoryImpl(
     profilesCollection.document(userId).update("profileImageUrl", imageUrl).await()
   }
 
-    override suspend fun searchProfiles(query: String, limit: Int): List<Profile> {
-        return profilesCollection
-            .get()
-            .await()
-            .documents
-            .mapNotNull { it.toObject(Profile::class.java) }
-            .filter { profile ->
-                profile.username.lowercase().contains(query.lowercase())
-            }
-            .take(limit)
-    }
+  override suspend fun searchProfiles(query: String, limit: Int): List<Profile> {
+    return profilesCollection
+        .get()
+        .await()
+        .documents
+        .mapNotNull { it.toObject(Profile::class.java) }
+        .filter { profile -> profile.username.lowercase().contains(query.lowercase()) }
+        .take(limit)
+  }
 
   override suspend fun createProfile(
       userId: String,

--- a/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
@@ -169,16 +169,17 @@ class ProfileRepositoryImpl(
     profilesCollection.document(userId).update("profileImageUrl", imageUrl).await()
   }
 
-  override suspend fun searchProfiles(query: String, limit: Int): List<Profile> {
-    return profilesCollection
-        .whereGreaterThanOrEqualTo("username", query)
-        .whereLessThanOrEqualTo("username", query + '\uf8ff')
-        .limit(limit.toLong())
-        .get()
-        .await()
-        .documents
-        .mapNotNull { it.toObject(Profile::class.java) }
-  }
+    override suspend fun searchProfiles(query: String, limit: Int): List<Profile> {
+        return profilesCollection
+            .get()
+            .await()
+            .documents
+            .mapNotNull { it.toObject(Profile::class.java) }
+            .filter { profile ->
+                profile.username.lowercase().contains(query.lowercase())
+            }
+            .take(limit)
+    }
 
   override suspend fun createProfile(
       userId: String,

--- a/app/src/main/java/com/github/se/eduverse/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/navigation/NavigationActions.kt
@@ -45,6 +45,13 @@ object Screen {
   const val PDF_CONVERTER = "PdfConverter screen"
   const val PROFILE = "Profile screen"
   const val SEARCH = "Search screen"
+
+  object USER_PROFILE {
+    const val route = "user_profile/{userId}"
+
+    // Helper function to create route with actual userId
+    fun createRoute(userId: String) = "user_profile/$userId"
+  }
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
@@ -131,5 +138,9 @@ open class NavigationActions(
    */
   open fun currentRoute(): String {
     return navController.currentDestination?.route ?: ""
+  }
+
+  fun navigateToUserProfile(userId: String) {
+    navController.navigate(Screen.USER_PROFILE.createRoute(userId))
   }
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
@@ -89,13 +89,6 @@ fun ProfileScreen(
                 else -> Text("Profile", modifier = Modifier.testTag("profile_title_default"))
               }
             },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("back_button")) {
-                    Icon(Icons.Default.ArrowBack, "Back")
-                  }
-            },
             actions = {
               IconButton(
                   onClick = { navigationActions.navigateTo(Screen.SETTING) },

--- a/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
@@ -206,7 +206,7 @@ private fun StatItem(label: String, count: Int, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun PublicationItem(
+fun PublicationItem(
     publication: Publication,
     onClick: () -> Unit,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Article
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
@@ -199,11 +198,7 @@ private fun StatItem(label: String, count: Int, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun PublicationItem(
-    publication: Publication,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
+fun PublicationItem(publication: Publication, onClick: () -> Unit, modifier: Modifier = Modifier) {
   Card(
       modifier = modifier.aspectRatio(1f).clickable(onClick = onClick),
       shape = RoundedCornerShape(8.dp)) {

--- a/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.github.se.eduverse.R
 import com.github.se.eduverse.model.Profile
+import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
 
@@ -34,7 +36,7 @@ const val TAG_PROFILE_USERNAME = "profile_username"
 const val TAG_PROFILE_STATS = "profile_stats"
 
 @Composable
-fun SearchProfileScreen(viewModel: ProfileViewModel, onProfileClick: (String) -> Unit) {
+fun SearchProfileScreen(navigationActions: NavigationActions,viewModel: ProfileViewModel) {
   var searchQuery by remember { mutableStateOf("") }
   val searchState by viewModel.searchState.collectAsState()
 
@@ -73,7 +75,7 @@ fun SearchProfileScreen(viewModel: ProfileViewModel, onProfileClick: (String) ->
               modifier = Modifier.testTag(TAG_PROFILE_LIST),
               verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(items = state.profiles, key = { it.id }) { profile ->
-                  ProfileSearchItem(profile = profile, onClick = { onProfileClick(profile.id) })
+                  ProfileSearchItem(profile = profile, onClick = { navigationActions.navigateToUserProfile(profile.id) })
                 }
               }
         }

--- a/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
@@ -38,168 +38,127 @@ const val TAG_PROFILE_STATS = "profile_stats"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchProfileScreen(navigationActions: NavigationActions, viewModel: ProfileViewModel) {
-    var searchQuery by remember { mutableStateOf("") }
-    val searchState by viewModel.searchState.collectAsState()
+  var searchQuery by remember { mutableStateOf("") }
+  val searchState by viewModel.searchState.collectAsState()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Search Users") },
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("search_back_button")
-                    ) {
-                        Icon(
-                            Icons.Default.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                }
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp)
-        ) {
-            TextField(
-                value = searchQuery,
-                onValueChange = {
-                    searchQuery = it
-                    viewModel.searchProfiles(it.lowercase())
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp)
-                    .testTag(TAG_SEARCH_FIELD),
-                placeholder = { Text("Search profiles...") },
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                singleLine = true
-            )
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text("Search Users") },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("search_back_button")) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                  }
+            })
+      }) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues).padding(16.dp)) {
+          TextField(
+              value = searchQuery,
+              onValueChange = {
+                searchQuery = it
+                viewModel.searchProfiles(it.lowercase())
+              },
+              modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag(TAG_SEARCH_FIELD),
+              placeholder = { Text("Search profiles...") },
+              leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+              singleLine = true)
 
-            when (val state = searchState) {
-                is SearchProfileState.Loading -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .testTag(TAG_LOADING_INDICATOR),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                }
-                is SearchProfileState.Success -> {
-                    if (state.profiles.isEmpty() && searchQuery.isNotEmpty()) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag(TAG_NO_RESULTS),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = "No profiles found",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    } else {
-                        LazyColumn(
-                            modifier = Modifier.testTag(TAG_PROFILE_LIST),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            items(
-                                items = state.profiles,
-                                key = { it.id }
-                            ) { profile ->
-                                ProfileSearchItem(
-                                    profile = profile,
-                                    onClick = { navigationActions.navigateToUserProfile(profile.id) }
-                                )
-                            }
-                        }
-                    }
-                }
-                is SearchProfileState.Error -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .testTag(TAG_ERROR_MESSAGE),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = state.message,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodyLarge
-                        )
-                    }
-                }
-                SearchProfileState.Idle -> {
-                    if (searchQuery.isEmpty()) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag(TAG_IDLE_MESSAGE),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = "Search for other users",
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
+          when (val state = searchState) {
+            is SearchProfileState.Loading -> {
+              Box(
+                  modifier = Modifier.fillMaxSize().testTag(TAG_LOADING_INDICATOR),
+                  contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                  }
             }
+            is SearchProfileState.Success -> {
+              if (state.profiles.isEmpty() && searchQuery.isNotEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize().testTag(TAG_NO_RESULTS),
+                    contentAlignment = Alignment.Center) {
+                      Text(
+                          text = "No profiles found",
+                          style = MaterialTheme.typography.bodyLarge,
+                          color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+              } else {
+                LazyColumn(
+                    modifier = Modifier.testTag(TAG_PROFILE_LIST),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                      items(items = state.profiles, key = { it.id }) { profile ->
+                        ProfileSearchItem(
+                            profile = profile,
+                            onClick = { navigationActions.navigateToUserProfile(profile.id) })
+                      }
+                    }
+              }
+            }
+            is SearchProfileState.Error -> {
+              Box(
+                  modifier = Modifier.fillMaxSize().testTag(TAG_ERROR_MESSAGE),
+                  contentAlignment = Alignment.Center) {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyLarge)
+                  }
+            }
+            SearchProfileState.Idle -> {
+              if (searchQuery.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize().testTag(TAG_IDLE_MESSAGE),
+                    contentAlignment = Alignment.Center) {
+                      Text(
+                          text = "Search for other users",
+                          style = MaterialTheme.typography.bodyLarge,
+                          color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+              }
+            }
+          }
         }
-    }
+      }
 }
 
 @Composable
 fun ProfileSearchItem(profile: Profile, onClick: () -> Unit) {
-    ListItem(
-        modifier = Modifier
-            .clickable(onClick = onClick)
-            .fillMaxWidth()
-            .testTag("${TAG_PROFILE_ITEM}_${profile.id}"),
-        headlineContent = {
-            Text(
-                text = profile.username,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.testTag("${TAG_PROFILE_USERNAME}_${profile.id}")
-            )
-        },
-        supportingContent = {
-            Row(
-                modifier = Modifier.testTag("${TAG_PROFILE_STATS}_${profile.id}"),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Text(
-                    text = "${profile.followers} followers",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = "${profile.following} following",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+  ListItem(
+      modifier =
+          Modifier.clickable(onClick = onClick)
+              .fillMaxWidth()
+              .testTag("${TAG_PROFILE_ITEM}_${profile.id}"),
+      headlineContent = {
+        Text(
+            text = profile.username,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.testTag("${TAG_PROFILE_USERNAME}_${profile.id}"))
+      },
+      supportingContent = {
+        Row(
+            modifier = Modifier.testTag("${TAG_PROFILE_STATS}_${profile.id}"),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+              Text(
+                  text = "${profile.followers} followers",
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant)
+              Text(
+                  text = "${profile.following} following",
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-        },
-        leadingContent = {
-            AsyncImage(
-                model = profile.profileImageUrl,
-                contentDescription = "Profile picture of ${profile.username}",
-                modifier = Modifier
-                    .size(48.dp)
+      },
+      leadingContent = {
+        AsyncImage(
+            model = profile.profileImageUrl,
+            contentDescription = "Profile picture of ${profile.username}",
+            modifier =
+                Modifier.size(48.dp)
                     .clip(CircleShape)
                     .testTag("${TAG_PROFILE_IMAGE}_${profile.id}"),
-                fallback = painterResource(R.drawable.eduverse_logo_alone)
-            )
-        }
-    )
+            fallback = painterResource(R.drawable.eduverse_logo_alone))
+      })
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -20,7 +21,6 @@ import coil.compose.AsyncImage
 import com.github.se.eduverse.R
 import com.github.se.eduverse.model.Profile
 import com.github.se.eduverse.ui.navigation.NavigationActions
-import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
 
@@ -35,114 +35,171 @@ const val TAG_PROFILE_IMAGE = "profile_image"
 const val TAG_PROFILE_USERNAME = "profile_username"
 const val TAG_PROFILE_STATS = "profile_stats"
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchProfileScreen(navigationActions: NavigationActions,viewModel: ProfileViewModel) {
-  var searchQuery by remember { mutableStateOf("") }
-  val searchState by viewModel.searchState.collectAsState()
+fun SearchProfileScreen(navigationActions: NavigationActions, viewModel: ProfileViewModel) {
+    var searchQuery by remember { mutableStateOf("") }
+    val searchState by viewModel.searchState.collectAsState()
 
-  Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-    TextField(
-        value = searchQuery,
-        onValueChange = {
-          searchQuery = it
-          viewModel.searchProfiles(it)
-        },
-        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag(TAG_SEARCH_FIELD),
-        placeholder = { Text("Search profiles...") },
-        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-        singleLine = true)
-
-    when (val state = searchState) {
-      is SearchProfileState.Loading -> {
-        Box(
-            modifier = Modifier.fillMaxSize().testTag(TAG_LOADING_INDICATOR),
-            contentAlignment = Alignment.Center) {
-              CircularProgressIndicator()
-            }
-      }
-      is SearchProfileState.Success -> {
-        if (state.profiles.isEmpty() && searchQuery.isNotEmpty()) {
-          Box(
-              modifier = Modifier.fillMaxSize().testTag(TAG_NO_RESULTS),
-              contentAlignment = Alignment.Center) {
-                Text(
-                    text = "No profiles found",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-              }
-        } else {
-          LazyColumn(
-              modifier = Modifier.testTag(TAG_PROFILE_LIST),
-              verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(items = state.profiles, key = { it.id }) { profile ->
-                  ProfileSearchItem(profile = profile, onClick = { navigationActions.navigateToUserProfile(profile.id) })
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Search Users") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("search_back_button")
+                    ) {
+                        Icon(
+                            Icons.Default.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
                 }
-              }
+            )
         }
-      }
-      is SearchProfileState.Error -> {
-        Box(
-            modifier = Modifier.fillMaxSize().testTag(TAG_ERROR_MESSAGE),
-            contentAlignment = Alignment.Center) {
-              Text(
-                  text = state.message,
-                  color = MaterialTheme.colorScheme.error,
-                  style = MaterialTheme.typography.bodyLarge)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            TextField(
+                value = searchQuery,
+                onValueChange = {
+                    searchQuery = it
+                    viewModel.searchProfiles(it.lowercase())
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+                    .testTag(TAG_SEARCH_FIELD),
+                placeholder = { Text("Search profiles...") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                singleLine = true
+            )
+
+            when (val state = searchState) {
+                is SearchProfileState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(TAG_LOADING_INDICATOR),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is SearchProfileState.Success -> {
+                    if (state.profiles.isEmpty() && searchQuery.isNotEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag(TAG_NO_RESULTS),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "No profiles found",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.testTag(TAG_PROFILE_LIST),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(
+                                items = state.profiles,
+                                key = { it.id }
+                            ) { profile ->
+                                ProfileSearchItem(
+                                    profile = profile,
+                                    onClick = { navigationActions.navigateToUserProfile(profile.id) }
+                                )
+                            }
+                        }
+                    }
+                }
+                is SearchProfileState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(TAG_ERROR_MESSAGE),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = state.message,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
+                SearchProfileState.Idle -> {
+                    if (searchQuery.isEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag(TAG_IDLE_MESSAGE),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Search for other users",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
             }
-      }
-      SearchProfileState.Idle -> {
-        if (searchQuery.isEmpty()) {
-          Box(
-              modifier = Modifier.fillMaxSize().testTag(TAG_IDLE_MESSAGE),
-              contentAlignment = Alignment.Center) {
-                Text(
-                    text = "Search for other users",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-              }
         }
-      }
     }
-  }
 }
 
 @Composable
 fun ProfileSearchItem(profile: Profile, onClick: () -> Unit) {
-  ListItem(
-      modifier =
-          Modifier.clickable(onClick = onClick)
-              .fillMaxWidth()
-              .testTag("${TAG_PROFILE_ITEM}_${profile.id}"),
-      headlineContent = {
-        Text(
-            text = profile.username,
-            style = MaterialTheme.typography.titleMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.testTag("${TAG_PROFILE_USERNAME}_${profile.id}"))
-      },
-      supportingContent = {
-        Row(
-            modifier = Modifier.testTag("${TAG_PROFILE_STATS}_${profile.id}"),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-              Text(
-                  text = "${profile.followers} followers",
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant)
-              Text(
-                  text = "${profile.following} following",
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant)
+    ListItem(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .fillMaxWidth()
+            .testTag("${TAG_PROFILE_ITEM}_${profile.id}"),
+        headlineContent = {
+            Text(
+                text = profile.username,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("${TAG_PROFILE_USERNAME}_${profile.id}")
+            )
+        },
+        supportingContent = {
+            Row(
+                modifier = Modifier.testTag("${TAG_PROFILE_STATS}_${profile.id}"),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "${profile.followers} followers",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "${profile.following} following",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-      },
-      leadingContent = {
-        AsyncImage(
-            model = profile.profileImageUrl,
-            contentDescription = "Profile picture of ${profile.username}",
-            modifier =
-                Modifier.size(48.dp)
+        },
+        leadingContent = {
+            AsyncImage(
+                model = profile.profileImageUrl,
+                contentDescription = "Profile picture of ${profile.username}",
+                modifier = Modifier
+                    .size(48.dp)
                     .clip(CircleShape)
                     .testTag("${TAG_PROFILE_IMAGE}_${profile.id}"),
-            fallback = painterResource(R.drawable.eduverse_logo_alone))
-      })
+                fallback = painterResource(R.drawable.eduverse_logo_alone)
+            )
+        }
+    )
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
@@ -1,0 +1,286 @@
+package com.github.se.eduverse.ui.search
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Article
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.github.se.eduverse.R
+import com.github.se.eduverse.model.Publication
+import com.github.se.eduverse.ui.navigation.NavigationActions
+import com.github.se.eduverse.ui.profile.PublicationDetailDialog
+import com.github.se.eduverse.ui.profile.PublicationItem
+import com.github.se.eduverse.viewmodel.ProfileUiState
+import com.github.se.eduverse.viewmodel.ProfileViewModel
+import com.google.firebase.auth.FirebaseAuth
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserProfileScreen(
+    navigationActions: NavigationActions,
+    viewModel: ProfileViewModel,
+    userId: String
+) {
+    var selectedTab by remember { mutableStateOf(0) }
+    val uiState by viewModel.profileState.collectAsState()
+    val likedPublications by viewModel.likedPublications.collectAsState(initial = emptyList())
+
+    LaunchedEffect(userId) {
+        viewModel.loadProfile(userId)
+        viewModel.loadLikedPublications(userId)
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag("user_profile_screen_container"),
+        topBar = {
+            TopAppBar(
+                modifier = Modifier.testTag("user_profile_top_bar"),
+                title = {
+                    when (uiState) {
+                        is ProfileUiState.Success ->
+                            Text(
+                                text = (uiState as ProfileUiState.Success).profile.username,
+                                modifier = Modifier.testTag("user_profile_username")
+                            )
+                        else -> Text("Profile", modifier = Modifier.testTag("user_profile_title_default"))
+                    }
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("back_button")
+                    ) {
+                        Icon(Icons.Default.ArrowBack, "Back")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .testTag("user_profile_content_container")
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Profile Image (non-editable)
+            Box(
+                modifier = Modifier
+                    .testTag("user_profile_image_container")
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = if (uiState is ProfileUiState.Success)
+                        (uiState as ProfileUiState.Success).profile.profileImageUrl
+                    else "",
+                    contentDescription = "Profile Image",
+                    modifier = Modifier
+                        .size(96.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    placeholder = painterResource(R.drawable.eduverse_logo_alone)
+                )
+            }
+
+            // Stats (Followers/Following)
+            when (uiState) {
+                is ProfileUiState.Success -> {
+                    val profile = (uiState as ProfileUiState.Success).profile
+                    Row(
+                        modifier = Modifier
+                            .testTag("stats_row")
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceEvenly
+                    ) {
+                        StatItem("Followers", profile.followers, Modifier.testTag("followers_stat"))
+                        StatItem("Following", profile.following, Modifier.testTag("following_stat"))
+                    }
+
+                    // Follow/Unfollow Button
+                    val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
+                    if (currentUserId != null && currentUserId != userId) {
+                        Button(
+                            onClick = {
+                                TODO()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                        ) {
+                            Text(if (profile.followers > 0) "Unfollow" else "Follow")
+                        }
+                    }
+                }
+                else -> {}
+            }
+
+            // Publications/Favorites Tabs
+            TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
+                Tab(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    modifier = Modifier.testTag("publications_tab"),
+                    text = { Text("Publications") },
+                    icon = { Icon(Icons.Default.Article, contentDescription = null) }
+                )
+                Tab(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    modifier = Modifier.testTag("favorites_tab"),
+                    text = { Text("Favorites") },
+                    icon = { Icon(Icons.Default.Favorite, contentDescription = null) }
+                )
+            }
+
+            // Content based on state
+            when (uiState) {
+                is ProfileUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .testTag("loading_container")
+                            .fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.testTag("loading_indicator"))
+                    }
+                }
+                is ProfileUiState.Error -> {
+                    ErrorMessage(
+                        message = (uiState as ProfileUiState.Error).message,
+                        modifier = Modifier.testTag("error_container")
+                    )
+                }
+                is ProfileUiState.Success -> {
+                    val profile = (uiState as ProfileUiState.Success).profile
+                    val publications = if (selectedTab == 0) {
+                        profile.publications
+                    } else {
+                        likedPublications
+                    }
+
+                    PublicationsGrid(
+                        publications = publications,
+                        currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: "",
+                        profileViewModel = viewModel,
+                        onPublicationClick = { /* Handle publication click */ },
+                        modifier = Modifier.testTag("publications_grid")
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorMessage(message: String, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.testTag("error_message"))
+    }
+}
+
+@Composable
+private fun StatItem(label: String, count: Int, modifier: Modifier = Modifier) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = count.toString(),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.testTag("stat_count_$label"))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("stat_label_$label"))
+    }
+}
+
+
+
+@Composable
+private fun PublicationsGrid(
+    publications: List<Publication>,
+    currentUserId: String,
+    profileViewModel: ProfileViewModel,
+    onPublicationClick: (Publication) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var selectedPublication by remember { mutableStateOf<Publication?>(null) }
+
+    if (publications.isEmpty()) {
+        Box(
+            modifier = Modifier.testTag("empty_publications_container").fillMaxSize(),
+            contentAlignment = Alignment.Center) {
+            Text(
+                text = "No publications yet",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("empty_publications_text"))
+        }
+    } else {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(3),
+            modifier = modifier.fillMaxSize(),
+            contentPadding = PaddingValues(1.dp),
+            horizontalArrangement = Arrangement.spacedBy(1.dp),
+            verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            items(publications) { publication ->
+                PublicationItem(
+                    publication = publication,
+                    onClick = { selectedPublication = publication },
+                    modifier = Modifier.testTag("publication_item_${publication.id}"))
+            }
+        }
+
+        // Show detail dialog when a publication is selected
+        selectedPublication?.let { publication ->
+            PublicationDetailDialog(
+                publication = publication,
+                profileViewModel = profileViewModel,
+                currentUserId = currentUserId,
+                onDismiss = { selectedPublication = null })
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
@@ -59,185 +59,160 @@ fun UserProfileScreen(
     viewModel: ProfileViewModel,
     userId: String
 ) {
-    var selectedTab by remember { mutableStateOf(0) }
-    val uiState by viewModel.profileState.collectAsState()
-    val likedPublications by viewModel.likedPublications.collectAsState(initial = emptyList())
+  var selectedTab by remember { mutableStateOf(0) }
+  val uiState by viewModel.profileState.collectAsState()
+  val likedPublications by viewModel.likedPublications.collectAsState(initial = emptyList())
 
-    LaunchedEffect(userId) {
-        viewModel.loadProfile(userId)
-        viewModel.loadLikedPublications(userId)
-    }
+  LaunchedEffect(userId) {
+    viewModel.loadProfile(userId)
+    viewModel.loadLikedPublications(userId)
+  }
 
-    Scaffold(
-        modifier = Modifier.testTag("user_profile_screen_container"),
-        topBar = {
-            TopAppBar(
-                modifier = Modifier.testTag("user_profile_top_bar"),
-                title = {
-                    when (uiState) {
-                        is ProfileUiState.Success ->
-                            Text(
-                                text = (uiState as ProfileUiState.Success).profile.username,
-                                modifier = Modifier.testTag("user_profile_username")
-                            )
-                        else -> Text("Profile", modifier = Modifier.testTag("user_profile_title_default"))
-                    }
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("back_button")
-                    ) {
-                        Icon(Icons.Default.ArrowBack, "Back")
-                    }
-                }
-            )
-        }
-    ) { paddingValues ->
+  Scaffold(
+      modifier = Modifier.testTag("user_profile_screen_container"),
+      topBar = {
+        TopAppBar(
+            modifier = Modifier.testTag("user_profile_top_bar"),
+            title = {
+              when (uiState) {
+                is ProfileUiState.Success ->
+                    Text(
+                        text = (uiState as ProfileUiState.Success).profile.username,
+                        modifier = Modifier.testTag("user_profile_username"))
+                else -> Text("Profile", modifier = Modifier.testTag("user_profile_title_default"))
+              }
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("back_button")) {
+                    Icon(Icons.Default.ArrowBack, "Back")
+                  }
+            })
+      }) { paddingValues ->
         Column(
-            modifier = Modifier
-                .testTag("user_profile_content_container")
-                .fillMaxSize()
-                .padding(paddingValues)
-        ) {
-            // Profile Image (non-editable)
-            Box(
-                modifier = Modifier
-                    .testTag("user_profile_image_container")
-                    .fillMaxWidth()
-                    .padding(top = 16.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                AsyncImage(
-                    model = if (uiState is ProfileUiState.Success)
-                        (uiState as ProfileUiState.Success).profile.profileImageUrl
-                    else "",
-                    contentDescription = "Profile Image",
-                    modifier = Modifier
-                        .size(96.dp)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                    placeholder = painterResource(R.drawable.eduverse_logo_alone)
-                )
-            }
+            modifier =
+                Modifier.testTag("user_profile_content_container")
+                    .fillMaxSize()
+                    .padding(paddingValues)) {
+              // Profile Image (non-editable)
+              Box(
+                  modifier =
+                      Modifier.testTag("user_profile_image_container")
+                          .fillMaxWidth()
+                          .padding(top = 16.dp),
+                  contentAlignment = Alignment.Center) {
+                    AsyncImage(
+                        model =
+                            if (uiState is ProfileUiState.Success)
+                                (uiState as ProfileUiState.Success).profile.profileImageUrl
+                            else "",
+                        contentDescription = "Profile Image",
+                        modifier = Modifier.size(96.dp).clip(CircleShape),
+                        contentScale = ContentScale.Crop,
+                        placeholder = painterResource(R.drawable.eduverse_logo_alone))
+                  }
 
-            // Stats (Followers/Following)
-            when (uiState) {
+              // Stats (Followers/Following)
+              when (uiState) {
                 is ProfileUiState.Success -> {
-                    val profile = (uiState as ProfileUiState.Success).profile
-                    Row(
-                        modifier = Modifier
-                            .testTag("stats_row")
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        horizontalArrangement = Arrangement.SpaceEvenly
-                    ) {
+                  val profile = (uiState as ProfileUiState.Success).profile
+                  Row(
+                      modifier = Modifier.testTag("stats_row").fillMaxWidth().padding(16.dp),
+                      horizontalArrangement = Arrangement.SpaceEvenly) {
                         StatItem("Followers", profile.followers, Modifier.testTag("followers_stat"))
                         StatItem("Following", profile.following, Modifier.testTag("following_stat"))
-                    }
+                      }
 
-                    // Follow/Unfollow Button
-                    val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
-                    if (currentUserId != null && currentUserId != userId) {
-                        Button(
-                            onClick = {
-                                TODO()
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                        ) {
-                            Text(if (profile.followers > 0) "Unfollow" else "Follow")
+                  // Follow/Unfollow Button
+                  val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
+                  if (currentUserId != null && currentUserId != userId) {
+                    Button(
+                        onClick = { TODO() },
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                          Text(if (profile.followers > 0) "Unfollow" else "Follow")
                         }
-                    }
+                  }
                 }
                 else -> {}
-            }
+              }
 
-            // Publications/Favorites Tabs
-            TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
+              // Publications/Favorites Tabs
+              TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
                 Tab(
                     selected = selectedTab == 0,
                     onClick = { selectedTab = 0 },
                     modifier = Modifier.testTag("publications_tab"),
                     text = { Text("Publications") },
-                    icon = { Icon(Icons.Default.Article, contentDescription = null) }
-                )
+                    icon = { Icon(Icons.Default.Article, contentDescription = null) })
                 Tab(
                     selected = selectedTab == 1,
                     onClick = { selectedTab = 1 },
                     modifier = Modifier.testTag("favorites_tab"),
                     text = { Text("Favorites") },
-                    icon = { Icon(Icons.Default.Favorite, contentDescription = null) }
-                )
-            }
+                    icon = { Icon(Icons.Default.Favorite, contentDescription = null) })
+              }
 
-            // Content based on state
-            when (uiState) {
+              // Content based on state
+              when (uiState) {
                 is ProfileUiState.Loading -> {
-                    Box(
-                        modifier = Modifier
-                            .testTag("loading_container")
-                            .fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
+                  Box(
+                      modifier = Modifier.testTag("loading_container").fillMaxSize(),
+                      contentAlignment = Alignment.Center) {
                         CircularProgressIndicator(modifier = Modifier.testTag("loading_indicator"))
-                    }
+                      }
                 }
                 is ProfileUiState.Error -> {
-                    ErrorMessage(
-                        message = (uiState as ProfileUiState.Error).message,
-                        modifier = Modifier.testTag("error_container")
-                    )
+                  ErrorMessage(
+                      message = (uiState as ProfileUiState.Error).message,
+                      modifier = Modifier.testTag("error_container"))
                 }
                 is ProfileUiState.Success -> {
-                    val profile = (uiState as ProfileUiState.Success).profile
-                    val publications = if (selectedTab == 0) {
+                  val profile = (uiState as ProfileUiState.Success).profile
+                  val publications =
+                      if (selectedTab == 0) {
                         profile.publications
-                    } else {
+                      } else {
                         likedPublications
-                    }
+                      }
 
-                    PublicationsGrid(
-                        publications = publications,
-                        currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: "",
-                        profileViewModel = viewModel,
-                        onPublicationClick = { /* Handle publication click */ },
-                        modifier = Modifier.testTag("publications_grid")
-                    )
+                  PublicationsGrid(
+                      publications = publications,
+                      currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: "",
+                      profileViewModel = viewModel,
+                      onPublicationClick = { /* Handle publication click */},
+                      modifier = Modifier.testTag("publications_grid"))
                 }
+              }
             }
-        }
-    }
+      }
 }
 
 @Composable
 private fun ErrorMessage(message: String, modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.error,
-            modifier = Modifier.testTag("error_message"))
-    }
+  Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.testTag("error_message"))
+  }
 }
 
 @Composable
 private fun StatItem(label: String, count: Int, modifier: Modifier = Modifier) {
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = count.toString(),
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.testTag("stat_count_$label"))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.testTag("stat_label_$label"))
-    }
+  Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Text(
+        text = count.toString(),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.testTag("stat_count_$label"))
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.testTag("stat_label_$label"))
+  }
 }
-
-
 
 @Composable
 private fun PublicationsGrid(
@@ -247,40 +222,40 @@ private fun PublicationsGrid(
     onPublicationClick: (Publication) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var selectedPublication by remember { mutableStateOf<Publication?>(null) }
+  var selectedPublication by remember { mutableStateOf<Publication?>(null) }
 
-    if (publications.isEmpty()) {
-        Box(
-            modifier = Modifier.testTag("empty_publications_container").fillMaxSize(),
-            contentAlignment = Alignment.Center) {
-            Text(
-                text = "No publications yet",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.testTag("empty_publications_text"))
+  if (publications.isEmpty()) {
+    Box(
+        modifier = Modifier.testTag("empty_publications_container").fillMaxSize(),
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = "No publications yet",
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.testTag("empty_publications_text"))
         }
-    } else {
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
-            modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(1.dp),
-            horizontalArrangement = Arrangement.spacedBy(1.dp),
-            verticalArrangement = Arrangement.spacedBy(1.dp)) {
-            items(publications) { publication ->
-                PublicationItem(
-                    publication = publication,
-                    onClick = { selectedPublication = publication },
-                    modifier = Modifier.testTag("publication_item_${publication.id}"))
-            }
-        }
-
-        // Show detail dialog when a publication is selected
-        selectedPublication?.let { publication ->
-            PublicationDetailDialog(
+  } else {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(1.dp),
+        horizontalArrangement = Arrangement.spacedBy(1.dp),
+        verticalArrangement = Arrangement.spacedBy(1.dp)) {
+          items(publications) { publication ->
+            PublicationItem(
                 publication = publication,
-                profileViewModel = profileViewModel,
-                currentUserId = currentUserId,
-                onDismiss = { selectedPublication = null })
+                onClick = { selectedPublication = publication },
+                modifier = Modifier.testTag("publication_item_${publication.id}"))
+          }
         }
+
+    // Show detail dialog when a publication is selected
+    selectedPublication?.let { publication ->
+      PublicationDetailDialog(
+          publication = publication,
+          profileViewModel = profileViewModel,
+          currentUserId = currentUserId,
+          onDismiss = { selectedPublication = null })
     }
+  }
 }


### PR DESCRIPTION
## Overview
This PR introduces a dedicated user profile viewing experience and enhances the search functionality with better UX. Users can now view other profiles through search, with appropriate UI/UX differences between personal and other users' profiles.

## Key Changes
- Add new UserProfileScreen for viewing other users' profiles
- Implement case-insensitive search with improved navigation
- Add comprehensive test coverage for new features
- Clean up code formatting

## Features
- Dynamic profile viewing based on user ID
- Restricted editing capabilities for non-personal profiles
- Smooth navigation between search and profile views
- Case-insensitive search functionality
- Back navigation from search and profile views

## Testing
- Added UserProfileScreen test suite
- Updated SearchProfileScreen tests for new features
- Maintained and cleaned up existing ProfileScreen tests

## Related Issues
Closes #151 - User profile viewing functionality
Fixes #154 - Search usability issues

## Screenshots

<div style="display: flex; justify-content: space-between; gap: 10px;">
    <img src="https://github.com/user-attachments/assets/ff958438-8244-4496-aeec-24975249b01b" width="32%" alt="Search Screen" />
    <img src="https://github.com/user-attachments/assets/14016664-b6e6-4ce7-9caa-f3fdb77c9605" width="32%" alt="Personal Profile" />
    <img src="https://github.com/user-attachments/assets/4c695f66-99dd-4d22-8860-ab4924d5539d" width="32%" alt="User Profile" />
</div>

## Notes
- Profile editing is restricted to personal profiles only
- Search results are now case-insensitive for better user experience
- Navigation flow has been optimized for better UX