### PR TITLE
Solve crash when rotating DisplayFolderScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,9 @@ plugins {
     alias(libs.plugins.gms)
     alias(libs.plugins.sonar)
     kotlin("kapt")
-    alias(libs.plugins.hilt)}
+    alias(libs.plugins.hilt)
+    id("kotlin-parcelize")}
+
 
 val hiltVersion = "2.48"
 

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.github.se.eduverse.repository.DashboardRepositoryImpl
 import com.github.se.eduverse.repository.FileRepositoryImpl
-import com.github.se.eduverse.repository.FolderRepositoryImpl
 import com.github.se.eduverse.repository.PhotoRepository
 import com.github.se.eduverse.repository.ProfileRepositoryImpl
 import com.github.se.eduverse.repository.PublicationRepository
@@ -119,8 +118,7 @@ fun EduverseApp(cameraPermissionGranted: Boolean) {
       ProfileRepositoryImpl(
           firestore = FirebaseFirestore.getInstance(), storage = FirebaseStorage.getInstance())
   val profileViewModel = ProfileViewModel(profileRepo)
-  val folderRepo = FolderRepositoryImpl(db = firestore)
-  val folderViewModel = FolderViewModel(folderRepo, FirebaseAuth.getInstance())
+  val folderViewModel: FolderViewModel = viewModel(factory = FolderViewModel.Factory)
   val pomodoroViewModel: TimerViewModel = viewModel()
   val fileRepo = FileRepositoryImpl(db = firestore, storage = FirebaseStorage.getInstance())
   val fileViewModel = FileViewModel(fileRepo)

--- a/app/src/main/java/com/github/se/eduverse/model/Folder.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/Folder.kt
@@ -1,5 +1,9 @@
 package com.github.se.eduverse.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Folder(
     val ownerID: String,
     var files: MutableList<MyFile>,
@@ -7,7 +11,7 @@ data class Folder(
     val id: String,
     var filterType: FilterTypes = FilterTypes.CREATION_UP,
     var archived: Boolean
-)
+) : Parcelable
 
 enum class FilterTypes {
   NAME,

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/FolderViewModel.kt
@@ -1,6 +1,8 @@
 package com.github.se.eduverse.viewmodel
 
 import android.util.Log
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.github.se.eduverse.model.FilterTypes
@@ -15,15 +17,23 @@ import java.util.Calendar
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-open class FolderViewModel(val repository: FolderRepository, val auth: FirebaseAuth) : ViewModel() {
+open class FolderViewModel(
+    val repository: FolderRepository,
+    val auth: FirebaseAuth,
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
+) : ViewModel() {
 
   companion object {
     val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
+        object : AbstractSavedStateViewModelFactory() {
           @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          override fun <T : ViewModel> create(
+              key: String,
+              modelClass: Class<T>,
+              handle: SavedStateHandle
+          ): T {
             return FolderViewModel(
-                FolderRepositoryImpl(Firebase.firestore), FirebaseAuth.getInstance())
+                FolderRepositoryImpl(Firebase.firestore), FirebaseAuth.getInstance(), handle)
                 as T
           }
         }
@@ -33,7 +43,8 @@ open class FolderViewModel(val repository: FolderRepository, val auth: FirebaseA
       MutableStateFlow(emptyList<Folder>().toMutableList())
   open val folders: StateFlow<MutableList<Folder>> = _folders
 
-  private var _activeFolder: MutableStateFlow<Folder?> = MutableStateFlow(null)
+  private var _activeFolder: MutableStateFlow<Folder?> =
+      MutableStateFlow(savedStateHandle["activeFolder"])
   val activeFolder: StateFlow<Folder?> = _activeFolder
 
   init {
@@ -51,6 +62,7 @@ open class FolderViewModel(val repository: FolderRepository, val auth: FirebaseA
    */
   fun selectFolder(folder: Folder?) {
     _activeFolder.value = folder
+    savedStateHandle["activeFolder"] = folder
   }
 
   /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
The bug was due to the app being reconstructed, reseting all view models including there state flow. The activeFolder of FolderViewModel was put to null, causing the app to crash.

This PR add a parameter savedStateHandle to FolderViewModel to save the value of activeFolder when the app is reconstructed. This handler has a default value to stay consistent with previous tests.