### PR TITLE
Make that notifications allow opening the app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -233,6 +233,9 @@ dependencies {
     // Networking with OkHttp
     implementation(libs.okhttp)
 
+    // Notifications with WorkManager
+    implementation("androidx.work:work-runtime-ktx:2.8.1")
+
     // Testing Unit
     testImplementation(libs.junit)
     androidTestImplementation(libs.mockk)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     //implementation("io.coil-kt:coil-compose:2.1.0")
     implementation("io.coil-kt:coil-compose:2.4.0")
     implementation(libs.androidx.junit.ktx)
+    implementation(libs.androidx.work.testing)
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.test:runner:1.5.2")

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/DetailsEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/DetailsEventScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performTextInput
 import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
 import com.github.se.eduverse.model.millisecInHour
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.TimeTableRepository
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.viewmodel.TimeTableViewModel
@@ -34,6 +35,7 @@ import org.mockito.kotlin.verify
 
 class DetailsEventScreenTest {
   private lateinit var timeTableRepository: TimeTableRepository
+  private lateinit var notificationRepository: NotificationRepository
   private lateinit var timeTableViewModel: TimeTableViewModel
   private lateinit var navigationActions: NavigationActions
   private lateinit var auth: FirebaseAuth
@@ -59,6 +61,7 @@ class DetailsEventScreenTest {
   @Before
   fun setUp() {
     timeTableRepository = mock(TimeTableRepository::class.java)
+    notificationRepository = mock(NotificationRepository::class.java)
     auth = mock(FirebaseAuth::class.java)
     val user = mock(FirebaseUser::class.java)
     navigationActions = mock(NavigationActions::class.java)
@@ -74,7 +77,7 @@ class DetailsEventScreenTest {
       callback()
     }
 
-    timeTableViewModel = TimeTableViewModel(timeTableRepository, auth)
+    timeTableViewModel = TimeTableViewModel(timeTableRepository, notificationRepository, auth)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/DetailsTasksScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/DetailsTasksScreenTest.kt
@@ -19,6 +19,7 @@ import com.github.se.eduverse.model.ScheduledType
 import com.github.se.eduverse.model.Todo
 import com.github.se.eduverse.model.TodoStatus
 import com.github.se.eduverse.model.millisecInHour
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.TimeTableRepository
 import com.github.se.eduverse.repository.TodoRepository
 import com.github.se.eduverse.ui.navigation.NavigationActions
@@ -40,6 +41,7 @@ import org.mockito.kotlin.verify
 
 class DetailsTasksScreenTest {
   private lateinit var timeTableRepository: TimeTableRepository
+  private lateinit var notificationRepository: NotificationRepository
   private lateinit var todoRepository: TodoRepository
   private lateinit var timeTableViewModel: TimeTableViewModel
   private lateinit var todoListViewModel: TodoListViewModel
@@ -68,6 +70,7 @@ class DetailsTasksScreenTest {
   @Before
   fun setUp() {
     timeTableRepository = mock(TimeTableRepository::class.java)
+    notificationRepository = mock(NotificationRepository::class.java)
     auth = mock(FirebaseAuth::class.java)
     val user = mock(FirebaseUser::class.java)
     navigationActions = mock(NavigationActions::class.java)
@@ -83,7 +86,7 @@ class DetailsTasksScreenTest {
       callback()
     }
 
-    timeTableViewModel = TimeTableViewModel(timeTableRepository, auth)
+    timeTableViewModel = TimeTableViewModel(timeTableRepository, notificationRepository, auth)
 
     todoRepository = mock(TodoRepository::class.java)
 

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/TimeTableScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/timetable/TimeTableScreenTest.kt
@@ -17,6 +17,7 @@ import com.github.se.eduverse.model.ScheduledType
 import com.github.se.eduverse.model.Todo
 import com.github.se.eduverse.model.TodoStatus
 import com.github.se.eduverse.model.millisecInHour
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.TimeTableRepository
 import com.github.se.eduverse.repository.TodoRepository
 import com.github.se.eduverse.ui.navigation.NavigationActions
@@ -39,6 +40,7 @@ import org.mockito.kotlin.verify
 class TimeTableScreenTest {
   private lateinit var todoRepository: TodoRepository
   private lateinit var timeTableRepository: TimeTableRepository
+  private lateinit var notificationRepository: NotificationRepository
   private lateinit var auth: FirebaseAuth
   private lateinit var user: FirebaseUser
   private lateinit var navigationActions: NavigationActions
@@ -87,6 +89,7 @@ class TimeTableScreenTest {
   fun setUp() {
     todoRepository = mock(TodoRepository::class.java)
     timeTableRepository = mock(TimeTableRepository::class.java)
+    notificationRepository = mock(NotificationRepository::class.java)
     auth = mock(FirebaseAuth::class.java)
     user = mock(FirebaseUser::class.java)
     navigationActions = mock(NavigationActions::class.java)
@@ -118,7 +121,7 @@ class TimeTableScreenTest {
     }
 
     todoListViewModel = TodoListViewModel(todoRepository)
-    timeTableViewModel = TimeTableViewModel(timeTableRepository, auth)
+    timeTableViewModel = TimeTableViewModel(timeTableRepository, notificationRepository, auth)
 
     composeTestRule.setContent {
       density = LocalDensity.current

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
@@ -23,8 +24,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
+import com.github.se.eduverse.model.NotifAutorisations
 import com.github.se.eduverse.repository.DashboardRepositoryImpl
 import com.github.se.eduverse.repository.FileRepositoryImpl
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.PhotoRepository
 import com.github.se.eduverse.repository.ProfileRepositoryImpl
 import com.github.se.eduverse.repository.PublicationRepository
@@ -167,7 +170,9 @@ fun EduverseApp(cameraPermissionGranted: Boolean) {
   val videoViewModel = VideoViewModel(videoRepo, fileRepo)
   val todoListViewModel: TodoListViewModel = viewModel(factory = TodoListViewModel.Factory)
   val timeTableRepo = TimeTableRepositoryImpl(firestore)
-  val timeTableViewModel = TimeTableViewModel(timeTableRepo, FirebaseAuth.getInstance())
+  val notifAutorisations = NotifAutorisations(true, true)
+  val notifRepo = NotificationRepository(LocalContext.current, notifAutorisations)
+  val timeTableViewModel = TimeTableViewModel(timeTableRepo, notifRepo, FirebaseAuth.getInstance())
   val pdfConverterViewModel: PdfConverterViewModel =
       viewModel(factory = PdfConverterViewModel.Factory)
 

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -24,7 +24,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
-import com.github.se.eduverse.model.NotifAutorisations
+import com.github.se.eduverse.model.NotifAutorizations
 import com.github.se.eduverse.repository.DashboardRepositoryImpl
 import com.github.se.eduverse.repository.FileRepositoryImpl
 import com.github.se.eduverse.repository.NotificationRepository
@@ -170,7 +170,7 @@ fun EduverseApp(cameraPermissionGranted: Boolean) {
   val videoViewModel = VideoViewModel(videoRepo, fileRepo)
   val todoListViewModel: TodoListViewModel = viewModel(factory = TodoListViewModel.Factory)
   val timeTableRepo = TimeTableRepositoryImpl(firestore)
-  val notifAutorisations = NotifAutorisations(true, true)
+  val notifAutorisations = NotifAutorizations(true, true)
   val notifRepo = NotificationRepository(LocalContext.current, notifAutorisations)
   val timeTableViewModel = TimeTableViewModel(timeTableRepo, notifRepo, FirebaseAuth.getInstance())
   val pdfConverterViewModel: PdfConverterViewModel =

--- a/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
@@ -1,6 +1,3 @@
 package com.github.se.eduverse.model
 
-data class NotifAutorisations(
-    var eventEnabled: Boolean,
-    var taskEnabled: Boolean
-)
+data class NotifAutorisations(var eventEnabled: Boolean, var taskEnabled: Boolean)

--- a/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
@@ -1,3 +1,0 @@
-package com.github.se.eduverse.model
-
-data class NotifAutorisations(var eventEnabled: Boolean, var taskEnabled: Boolean)

--- a/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/NotifAutorisations.kt
@@ -1,0 +1,6 @@
+package com.github.se.eduverse.model
+
+data class NotifAutorisations(
+    var eventEnabled: Boolean,
+    var taskEnabled: Boolean
+)

--- a/app/src/main/java/com/github/se/eduverse/model/NotifAutorizations.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/NotifAutorizations.kt
@@ -1,0 +1,3 @@
+package com.github.se.eduverse.model
+
+data class NotifAutorizations(var eventEnabled: Boolean, var taskEnabled: Boolean)

--- a/app/src/main/java/com/github/se/eduverse/model/NotificationData.kt
+++ b/app/src/main/java/com/github/se/eduverse/model/NotificationData.kt
@@ -1,0 +1,12 @@
+package com.github.se.eduverse.model
+
+/*
+This class represent the data of a notification, if the app is opened by one. It's goal is to
+be able to scale the notification system by adding new notifications channels, and to reduce
+the amount of argument of EduverseApp (in comparison to just passing every field one by one)
+ */
+data class NotificationData(
+    var isNotification: Boolean,
+    val objectId: String? = null,
+    var onOpen: suspend () -> Unit = {}
+)

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -15,7 +15,6 @@ import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
 import java.util.concurrent.TimeUnit
 
-
 // Parameter authorizations is not used for now, it is here to make the class easier to upgrade
 open class NotificationRepository(context: Context, val autorizations: NotifAutorizations) {
   private val applicationContext: Context = context.applicationContext

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -20,7 +20,7 @@ open class NotificationRepository(context: Context, val autorisations: NotifAuto
     private val applicationContext: Context = context.applicationContext
 
     open fun scheduleNotification(scheduled: Scheduled) {
-        WorkManager.getInstance(applicationContext).cancelAllWorkByTag(scheduled.id)
+        cancelNotification(scheduled)
 
         val delay = scheduled.start.timeInMillis - System.currentTimeMillis()
 
@@ -43,6 +43,10 @@ open class NotificationRepository(context: Context, val autorisations: NotifAuto
                 "Scheduled time is in the past for task: ${scheduled.name}"
             )
         }
+    }
+
+    open fun cancelNotification(scheduled: Scheduled) {
+        WorkManager.getInstance(applicationContext).cancelAllWorkByTag(scheduled.id)
     }
 
     fun createTitle(scheduled: Scheduled): String {

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -21,18 +21,19 @@ open class NotificationRepository(
     val autorizations: NotifAutorizations,
     val workManager: WorkManager = WorkManager.getInstance(context)
 ) {
-    /**
-     * Prepare a notification for an event or a task
-     *
-     * @param scheduled the event/task scheduled
-     */
+  /**
+   * Prepare a notification for an event or a task
+   *
+   * @param scheduled the event/task scheduled
+   */
   open fun scheduleNotification(scheduled: Scheduled) {
     cancelNotification(scheduled)
 
     val delay = scheduled.start.timeInMillis - System.currentTimeMillis()
 
     if (delay > 0) {
-      val workRequest = OneTimeWorkRequestBuilder<NotificationWorker>()
+      val workRequest =
+          OneTimeWorkRequestBuilder<NotificationWorker>()
               .setInitialDelay(delay, TimeUnit.MILLISECONDS)
               .addTag(scheduled.id)
               .setInputData(
@@ -45,20 +46,20 @@ open class NotificationRepository(
     }
   }
 
-    /**
-     * Cancel the eventual planned notification for a scheduled
-     *
-     * @param scheduled the scheduled to cancel
-     */
+  /**
+   * Cancel the eventual planned notification for a scheduled
+   *
+   * @param scheduled the scheduled to cancel
+   */
   open fun cancelNotification(scheduled: Scheduled) {
-      workManager.cancelAllWorkByTag(scheduled.id)
+    workManager.cancelAllWorkByTag(scheduled.id)
   }
 
-    /**
-     * Create a title depending on the type of the scheduled
-     *
-     * @param scheduled the scheduled
-     */
+  /**
+   * Create a title depending on the type of the scheduled
+   *
+   * @param scheduled the scheduled
+   */
   fun createTitle(scheduled: Scheduled): String {
     if (scheduled.type == ScheduledType.TASK) {
       return "You should start working on a task."
@@ -71,10 +72,8 @@ open class NotificationRepository(
 class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
     Worker(context, workerParameters) {
 
-    /**
-     * Called at the time the work was planned
-     */
-    override fun doWork(): Result {
+  /** Called at the time the work was planned */
+  override fun doWork(): Result {
     val title = inputData.getString("title") ?: "Reminder"
     val description = inputData.getString("description") ?: "No details"
 
@@ -82,13 +81,13 @@ class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
     return Result.success()
   }
 
-    /**
-     * Create a notification
-     *
-     * @param title the title of the notification
-     * @param text the text of the notification
-     * @param notificationManager dependency injection for testing purpose
-     */
+  /**
+   * Create a notification
+   *
+   * @param title the title of the notification
+   * @param text the text of the notification
+   * @param notificationManager dependency injection for testing purpose
+   */
   fun showNotification(
       title: String,
       text: String,
@@ -103,7 +102,8 @@ class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
             .apply { description = "Notifications for scheduled tasks" }
     notificationManager.createNotificationChannel(channel)
 
-    val notification = NotificationCompat.Builder(applicationContext, channelId)
+    val notification =
+        NotificationCompat.Builder(applicationContext, channelId)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle(title)
             .setContentText(text)

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -1,0 +1,89 @@
+package com.github.se.eduverse.repository
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.github.se.eduverse.model.Scheduled
+import com.github.se.eduverse.model.ScheduledType
+import java.util.concurrent.TimeUnit
+
+
+open class NotificationRepository(context: Context) {
+    private val applicationContext: Context = context.applicationContext
+
+    open fun scheduleNotification(scheduled: Scheduled) {
+        WorkManager.getInstance(applicationContext).cancelAllWorkByTag(scheduled.id)
+
+        val delay = scheduled.start.timeInMillis - System.currentTimeMillis()
+
+        if (delay > 0) {
+            val workRequest = OneTimeWorkRequestBuilder<NotificationWorker>()
+                .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+                .addTag(scheduled.id)
+                .setInputData(
+                    workDataOf(
+                        "title" to createTitle(scheduled),
+                        "description" to scheduled.name
+                    )
+                )
+                .build()
+
+            WorkManager.getInstance(applicationContext).enqueue(workRequest)
+        } else {
+            Log.w(
+                "NotificationScheduler",
+                "Scheduled time is in the past for task: ${scheduled.name}"
+            )
+        }
+    }
+
+    fun createTitle(scheduled: Scheduled): String {
+        if (scheduled.type == ScheduledType.TASK) {
+            return "You should start working on task."
+        } else {
+            return "An event is about to begin !"
+        }
+    }
+}
+
+class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
+    Worker(context, workerParameters) {
+
+    override fun doWork(): Result {
+        val title = inputData.getString("title") ?: "Reminder"
+        val description = inputData.getString("description") ?: "No details"
+
+        showNotification(title, description)
+        return Result.success()
+    }
+
+    private fun showNotification(title: String, text: String) {
+        val channelId = "task_channel"
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Create Notification Channel (Android 8.0+)
+        val channel = NotificationChannel(
+            channelId,
+            "Task Notifications",
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply { description = "Notifications for scheduled tasks" }
+        notificationManager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(applicationContext, channelId)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+
+        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+    }
+}

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -21,6 +21,11 @@ open class NotificationRepository(
     val autorizations: NotifAutorizations,
     val workManager: WorkManager = WorkManager.getInstance(context)
 ) {
+    /**
+     * Prepare a notification for an event or a task
+     *
+     * @param scheduled the event/task scheduled
+     */
   open fun scheduleNotification(scheduled: Scheduled) {
     cancelNotification(scheduled)
 
@@ -40,10 +45,20 @@ open class NotificationRepository(
     }
   }
 
+    /**
+     * Cancel the eventual planned notification for a scheduled
+     *
+     * @param scheduled the scheduled to cancel
+     */
   open fun cancelNotification(scheduled: Scheduled) {
       workManager.cancelAllWorkByTag(scheduled.id)
   }
 
+    /**
+     * Create a title depending on the type of the scheduled
+     *
+     * @param scheduled the scheduled
+     */
   fun createTitle(scheduled: Scheduled): String {
     if (scheduled.type == ScheduledType.TASK) {
       return "You should start working on a task."
@@ -56,7 +71,10 @@ open class NotificationRepository(
 class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
     Worker(context, workerParameters) {
 
-  override fun doWork(): Result {
+    /**
+     * Called at the time the work was planned
+     */
+    override fun doWork(): Result {
     val title = inputData.getString("title") ?: "Reminder"
     val description = inputData.getString("description") ?: "No details"
 
@@ -64,6 +82,13 @@ class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
     return Result.success()
   }
 
+    /**
+     * Create a notification
+     *
+     * @param title the title of the notification
+     * @param text the text of the notification
+     * @param notificationManager dependency injection for testing purpose
+     */
   fun showNotification(
       title: String,
       text: String,

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -10,12 +10,13 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.github.se.eduverse.model.NotifAutorisations
 import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
 import java.util.concurrent.TimeUnit
 
 
-open class NotificationRepository(context: Context) {
+open class NotificationRepository(context: Context, val autorisations: NotifAutorisations) {
     private val applicationContext: Context = context.applicationContext
 
     open fun scheduleNotification(scheduled: Scheduled) {

--- a/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/NotificationRepository.kt
@@ -10,12 +10,14 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
-import com.github.se.eduverse.model.NotifAutorisations
+import com.github.se.eduverse.model.NotifAutorizations
 import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
 import java.util.concurrent.TimeUnit
 
-open class NotificationRepository(context: Context, val autorisations: NotifAutorisations) {
+
+// Parameter authorizations is not used for now, it is here to make the class easier to upgrade
+open class NotificationRepository(context: Context, val autorizations: NotifAutorizations) {
   private val applicationContext: Context = context.applicationContext
 
   open fun scheduleNotification(scheduled: Scheduled) {
@@ -69,7 +71,7 @@ class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
 
     // Create Notification Channel (Android 8.0+)
     val channel =
-        NotificationChannel(channelId, "Task Notifications", NotificationManager.IMPORTANCE_DEFAULT)
+        NotificationChannel(channelId, "Task Notifications", NotificationManager.IMPORTANCE_HIGH)
             .apply { description = "Notifications for scheduled tasks" }
     notificationManager.createNotificationChannel(channel)
 
@@ -78,7 +80,7 @@ class NotificationWorker(context: Context, workerParameters: WorkerParameters) :
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle(title)
             .setContentText(text)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .build()
 
     notificationManager.notify(System.currentTimeMillis().toInt(), notification)

--- a/app/src/main/java/com/github/se/eduverse/repository/TimeTableRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/TimeTableRepository.kt
@@ -13,6 +13,8 @@ interface TimeTableRepository {
       onFailure: (Exception) -> Unit
   )
 
+  suspend fun getScheduledById(id: String): Scheduled
+
   fun addScheduled(scheduled: Scheduled, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun updateScheduled(scheduled: Scheduled, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)

--- a/app/src/main/java/com/github/se/eduverse/repository/TimeTableRepositoryImpl.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/TimeTableRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.github.se.eduverse.model.ScheduledType
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import java.util.Calendar
+import kotlinx.coroutines.tasks.await
 
 open class TimeTableRepositoryImpl(val db: FirebaseFirestore) : TimeTableRepository {
   private val collection = db.collection("scheduled")
@@ -40,6 +41,11 @@ open class TimeTableRepositoryImpl(val db: FirebaseFirestore) : TimeTableReposit
           onSuccess(it.documents.map { document -> convertScheduled(document) })
         }
         .addOnFailureListener(onFailure)
+  }
+
+  override suspend fun getScheduledById(id: String): Scheduled {
+    val document = collection.document(id).get().await()
+    return convertScheduled(document)
   }
 
   override fun addScheduled(

--- a/app/src/main/java/com/github/se/eduverse/ui/authentification/Loading.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/authentification/Loading.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.eduverse.R
+import com.github.se.eduverse.model.NotificationData
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.Route
 import com.github.se.eduverse.ui.navigation.TopLevelDestination
@@ -32,7 +33,7 @@ import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.delay
 
 @Composable
-fun LoadingScreen(navigationActions: NavigationActions) {
+fun LoadingScreen(navigationActions: NavigationActions, notificationData: NotificationData) {
 
   val auth = FirebaseAuth.getInstance()
 
@@ -40,7 +41,12 @@ fun LoadingScreen(navigationActions: NavigationActions) {
     delay(1300)
     // Wait for Firebase Auth to initialize
     if (auth.currentUser != null) {
-      navigationActions.navigateTo(TopLevelDestinations.DASHBOARD)
+      if (notificationData.isNotification) {
+        notificationData.isNotification = false // To avoid being unable to go back
+        notificationData.onOpen()
+      } else {
+        navigationActions.navigateTo(TopLevelDestinations.DASHBOARD)
+      }
     } else {
       navigationActions.navigateTo(
           TopLevelDestination(route = Route.AUTH, icon = Icons.Outlined.AutoGraph, textId = "Auth"))

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
@@ -121,7 +121,7 @@ class TimeTableViewModel(
                     .sortedBy { it.start.timeInMillis }
               }
 
-            notificationRepository.scheduleNotification(scheduled)
+          notificationRepository.scheduleNotification(scheduled)
         },
         { Log.e("TimeTableViewModel", "Exception $it while trying to modify a scheduled event") })
   }
@@ -135,8 +135,8 @@ class TimeTableViewModel(
     timeTableRepository.deleteScheduled(
         scheduled,
         {
-            _table.value = _table.value.map { innerList -> innerList - scheduled }
-            notificationRepository.cancelNotification(scheduled)
+          _table.value = _table.value.map { innerList -> innerList - scheduled }
+          notificationRepository.cancelNotification(scheduled)
         },
         { Log.e("TimeTableViewModel", "Exception $it while trying to delete a scheduled event") })
   }

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
@@ -120,6 +120,8 @@ class TimeTableViewModel(
                     .map { if (it.id == scheduled.id) scheduled else it }
                     .sortedBy { it.start.timeInMillis }
               }
+
+            notificationRepository.scheduleNotification(scheduled)
         },
         { Log.e("TimeTableViewModel", "Exception $it while trying to modify a scheduled event") })
   }
@@ -132,7 +134,10 @@ class TimeTableViewModel(
   fun deleteScheduled(scheduled: Scheduled) {
     timeTableRepository.deleteScheduled(
         scheduled,
-        { _table.value = _table.value.map { innerList -> innerList - scheduled } },
+        {
+            _table.value = _table.value.map { innerList -> innerList - scheduled }
+            notificationRepository.cancelNotification(scheduled)
+        },
         { Log.e("TimeTableViewModel", "Exception $it while trying to delete a scheduled event") })
   }
 

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
@@ -51,6 +51,15 @@ class TimeTableViewModel(
   }
 
   /**
+   * Return the scheduled with given id
+   *
+   * @param id the id of the scheduled
+   */
+  suspend fun getScheduledById(id: String): Scheduled {
+    return timeTableRepository.getScheduledById(id)
+  }
+
+  /**
    * Change the active week to the next one, and access the scheduled events and tasks in that week
    */
   fun getNextWeek() {

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/TimeTableViewModel.kt
@@ -6,6 +6,7 @@ import com.github.se.eduverse.model.WeeklyTable
 import com.github.se.eduverse.model.daysInWeek
 import com.github.se.eduverse.model.emptyWeeklyTable
 import com.github.se.eduverse.model.millisecInDay
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.TimeTableRepository
 import com.google.firebase.auth.FirebaseAuth
 import java.text.SimpleDateFormat
@@ -14,7 +15,11 @@ import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class TimeTableViewModel(val timeTableRepository: TimeTableRepository, val auth: FirebaseAuth) {
+class TimeTableViewModel(
+    val timeTableRepository: TimeTableRepository,
+    val notificationRepository: NotificationRepository,
+    val auth: FirebaseAuth
+) {
   private val _currentWeek =
       MutableStateFlow(
           Calendar.getInstance().apply {
@@ -94,6 +99,8 @@ class TimeTableViewModel(val timeTableRepository: TimeTableRepository, val auth:
               currentTime += millisecInDay
             }
           }
+
+          notificationRepository.scheduleNotification(scheduled)
         },
         { Log.e("TimeTableViewModel", "Exception $it while trying to schedule an event") })
   }

--- a/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
@@ -130,9 +130,10 @@ class NotificationRepositoryTest {
   fun showNotificationCreatesNotification() {
     val title = "Test Title"
     val text = "Test Description"
+    val id = "Scheduled Id"
 
     // Call showNotification directly
-    notificationWorker.showNotification(title, text, notificationManager)
+    notificationWorker.showNotification(title, text, id, notificationManager)
 
     // Verify that the notification was created
     verify(notificationManager).createNotificationChannel(any())

--- a/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
@@ -1,0 +1,149 @@
+package com.github.se.eduverse.repository
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.testing.TestWorkerBuilder
+import com.github.se.eduverse.model.NotifAutorizations
+import com.github.se.eduverse.model.Scheduled
+import com.github.se.eduverse.model.ScheduledType
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationRepositoryTest {
+
+    private lateinit var context: Context
+    private lateinit var mockWorkManager: WorkManager
+    private lateinit var repository: NotificationRepository
+    private lateinit var notificationManager: NotificationManager
+    private lateinit var notificationWorker: NotificationWorker
+
+    private val notifAut = NotifAutorizations(true, true)
+
+    private val scheduled =
+        Scheduled(
+            "id",
+            ScheduledType.TASK,
+            Calendar.getInstance(),
+            7,
+            "taskId",
+            "ownerId",
+            "name")
+
+    @Before
+    fun setup() {
+        // Initialize the WorkManager for testing
+        context = ApplicationProvider.getApplicationContext()
+        mockWorkManager = mock(WorkManager::class.java)
+
+        // Create the repository instance with mocks
+        repository = NotificationRepository(context, notifAut, mockWorkManager)
+
+        // Create the notification manager and worker
+        notificationManager = mock(NotificationManager::class.java)
+
+        val inputData = Data.Builder()
+            .putString("title", "Test Title")
+            .putString("description", "Test Description")
+            .build()
+
+        notificationWorker = TestWorkerBuilder.from(
+            context,
+            NotificationWorker::class.java
+        )
+            .setInputData(inputData)
+            .build()
+    }
+
+    @Test
+    fun scheduleNotificationEnqueuesWorkWhenDelayIsPositive() {
+        // Arrange
+        scheduled.start.add(Calendar.MINUTE, 1)
+
+        // Act
+        repository.scheduleNotification(scheduled)
+
+        // Assert
+        verify(mockWorkManager).enqueue(any<WorkRequest>())
+    }
+
+    @Test
+    fun scheduleNotificationLogsWarningWhenDelayIsNegative() {
+        // Arrange
+        scheduled.start.add(Calendar.MINUTE, -1)
+
+        // Act
+        repository.scheduleNotification(scheduled)
+
+        // Assert
+        verify(mockWorkManager, never()).enqueue(any<WorkRequest>())
+    }
+
+    @Test
+    fun cancelNotificationCancelsWorkByTag() {
+        // Act
+        repository.cancelNotification(scheduled)
+
+        // Assert
+        verify(mockWorkManager).cancelAllWorkByTag(any())
+    }
+
+    @Test
+    fun createTitleReturnsCorrectTitleForTASKType() {
+        // Act
+        val title = repository.createTitle(scheduled)
+
+        // Assert
+        assertEquals("You should start working on a task.", title)
+    }
+
+    @Test
+    fun createTitleReturnsCorrectTitleForEVENTType() {
+        // Arrange
+        val event = Scheduled(
+            id = "test_id",
+            type = ScheduledType.EVENT,
+            start = Calendar.getInstance(),
+            length = 0,
+            content = "",
+            ownerId = "",
+            name = "Test Event"
+        )
+
+        // Act
+        val title = repository.createTitle(event)
+
+        // Assert
+        assertEquals("An event is about to begin !", title)
+    }
+
+    @Test
+    fun doWorkReturnsSuccess() {
+        val result = notificationWorker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun showNotificationCreatesNotification() {
+        val title = "Test Title"
+        val text = "Test Description"
+
+        // Call showNotification directly
+        notificationWorker.showNotification(title, text, notificationManager)
+
+        // Verify that the notification was created
+        verify(notificationManager).createNotificationChannel(any())
+        verify(notificationManager).notify(anyInt(), any())
+    }
+}

--- a/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/NotificationRepositoryTest.kt
@@ -11,139 +11,131 @@ import androidx.work.testing.TestWorkerBuilder
 import com.github.se.eduverse.model.NotifAutorizations
 import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
+import java.util.Calendar
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
 import org.robolectric.RobolectricTestRunner
-import java.util.Calendar
 
 @RunWith(RobolectricTestRunner::class)
 class NotificationRepositoryTest {
 
-    private lateinit var context: Context
-    private lateinit var mockWorkManager: WorkManager
-    private lateinit var repository: NotificationRepository
-    private lateinit var notificationManager: NotificationManager
-    private lateinit var notificationWorker: NotificationWorker
+  private lateinit var context: Context
+  private lateinit var mockWorkManager: WorkManager
+  private lateinit var repository: NotificationRepository
+  private lateinit var notificationManager: NotificationManager
+  private lateinit var notificationWorker: NotificationWorker
 
-    private val notifAut = NotifAutorizations(true, true)
+  private val notifAut = NotifAutorizations(true, true)
 
-    private val scheduled =
-        Scheduled(
-            "id",
-            ScheduledType.TASK,
-            Calendar.getInstance(),
-            7,
-            "taskId",
-            "ownerId",
-            "name")
+  private val scheduled =
+      Scheduled("id", ScheduledType.TASK, Calendar.getInstance(), 7, "taskId", "ownerId", "name")
 
-    @Before
-    fun setup() {
-        // Initialize the WorkManager for testing
-        context = ApplicationProvider.getApplicationContext()
-        mockWorkManager = mock(WorkManager::class.java)
+  @Before
+  fun setup() {
+    // Initialize the WorkManager for testing
+    context = ApplicationProvider.getApplicationContext()
+    mockWorkManager = mock(WorkManager::class.java)
 
-        // Create the repository instance with mocks
-        repository = NotificationRepository(context, notifAut, mockWorkManager)
+    // Create the repository instance with mocks
+    repository = NotificationRepository(context, notifAut, mockWorkManager)
 
-        // Create the notification manager and worker
-        notificationManager = mock(NotificationManager::class.java)
+    // Create the notification manager and worker
+    notificationManager = mock(NotificationManager::class.java)
 
-        val inputData = Data.Builder()
+    val inputData =
+        Data.Builder()
             .putString("title", "Test Title")
             .putString("description", "Test Description")
             .build()
 
-        notificationWorker = TestWorkerBuilder.from(
-            context,
-            NotificationWorker::class.java
-        )
+    notificationWorker =
+        TestWorkerBuilder.from(context, NotificationWorker::class.java)
             .setInputData(inputData)
             .build()
-    }
+  }
 
-    @Test
-    fun scheduleNotificationEnqueuesWorkWhenDelayIsPositive() {
-        // Arrange
-        scheduled.start.add(Calendar.MINUTE, 1)
+  @Test
+  fun scheduleNotificationEnqueuesWorkWhenDelayIsPositive() {
+    // Arrange
+    scheduled.start.add(Calendar.MINUTE, 1)
 
-        // Act
-        repository.scheduleNotification(scheduled)
+    // Act
+    repository.scheduleNotification(scheduled)
 
-        // Assert
-        verify(mockWorkManager).enqueue(any<WorkRequest>())
-    }
+    // Assert
+    verify(mockWorkManager).enqueue(any<WorkRequest>())
+  }
 
-    @Test
-    fun scheduleNotificationLogsWarningWhenDelayIsNegative() {
-        // Arrange
-        scheduled.start.add(Calendar.MINUTE, -1)
+  @Test
+  fun scheduleNotificationLogsWarningWhenDelayIsNegative() {
+    // Arrange
+    scheduled.start.add(Calendar.MINUTE, -1)
 
-        // Act
-        repository.scheduleNotification(scheduled)
+    // Act
+    repository.scheduleNotification(scheduled)
 
-        // Assert
-        verify(mockWorkManager, never()).enqueue(any<WorkRequest>())
-    }
+    // Assert
+    verify(mockWorkManager, never()).enqueue(any<WorkRequest>())
+  }
 
-    @Test
-    fun cancelNotificationCancelsWorkByTag() {
-        // Act
-        repository.cancelNotification(scheduled)
+  @Test
+  fun cancelNotificationCancelsWorkByTag() {
+    // Act
+    repository.cancelNotification(scheduled)
 
-        // Assert
-        verify(mockWorkManager).cancelAllWorkByTag(any())
-    }
+    // Assert
+    verify(mockWorkManager).cancelAllWorkByTag(any())
+  }
 
-    @Test
-    fun createTitleReturnsCorrectTitleForTASKType() {
-        // Act
-        val title = repository.createTitle(scheduled)
+  @Test
+  fun createTitleReturnsCorrectTitleForTASKType() {
+    // Act
+    val title = repository.createTitle(scheduled)
 
-        // Assert
-        assertEquals("You should start working on a task.", title)
-    }
+    // Assert
+    assertEquals("You should start working on a task.", title)
+  }
 
-    @Test
-    fun createTitleReturnsCorrectTitleForEVENTType() {
-        // Arrange
-        val event = Scheduled(
+  @Test
+  fun createTitleReturnsCorrectTitleForEVENTType() {
+    // Arrange
+    val event =
+        Scheduled(
             id = "test_id",
             type = ScheduledType.EVENT,
             start = Calendar.getInstance(),
             length = 0,
             content = "",
             ownerId = "",
-            name = "Test Event"
-        )
+            name = "Test Event")
 
-        // Act
-        val title = repository.createTitle(event)
+    // Act
+    val title = repository.createTitle(event)
 
-        // Assert
-        assertEquals("An event is about to begin !", title)
-    }
+    // Assert
+    assertEquals("An event is about to begin !", title)
+  }
 
-    @Test
-    fun doWorkReturnsSuccess() {
-        val result = notificationWorker.doWork()
+  @Test
+  fun doWorkReturnsSuccess() {
+    val result = notificationWorker.doWork()
 
-        assertEquals(ListenableWorker.Result.success(), result)
-    }
+    assertEquals(ListenableWorker.Result.success(), result)
+  }
 
-    @Test
-    fun showNotificationCreatesNotification() {
-        val title = "Test Title"
-        val text = "Test Description"
+  @Test
+  fun showNotificationCreatesNotification() {
+    val title = "Test Title"
+    val text = "Test Description"
 
-        // Call showNotification directly
-        notificationWorker.showNotification(title, text, notificationManager)
+    // Call showNotification directly
+    notificationWorker.showNotification(title, text, notificationManager)
 
-        // Verify that the notification was created
-        verify(notificationManager).createNotificationChannel(any())
-        verify(notificationManager).notify(anyInt(), any())
-    }
+    // Verify that the notification was created
+    verify(notificationManager).createNotificationChannel(any())
+    verify(notificationManager).notify(anyInt(), any())
+  }
 }

--- a/app/src/test/java/com/github/se/eduverse/repository/TimeTableRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/TimeTableRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import java.util.Calendar
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -116,6 +117,15 @@ class TimeTableRepositoryTest {
         Calendar.getInstance(), "ownerId", { assert(false) }, { test = true })
     shadowOf(Looper.getMainLooper()).idle()
     assert(test)
+  }
+
+  @Test
+  fun getScheduledByIdTest() = runBlocking {
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(documentSnapshot))
+    val result = timeTableRepository.getScheduledById("")
+
+    assertEquals("id", result.id)
+    assertEquals("name", result.name)
   }
 
   @Test

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
@@ -9,12 +9,14 @@ import com.google.firebase.auth.FirebaseUser
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 class TimeTableViewModelTest {
@@ -91,6 +93,12 @@ class TimeTableViewModelTest {
   fun getNewUidTest() {
     assertEquals("uid", timeTableViewModel.getNewUid())
     verify(timeTableRepository).getNewUid()
+  }
+
+  @Test
+  fun getScheduledByIdTest(): Unit = runBlocking {
+    timeTableViewModel.getScheduledById("")
+    verify(timeTableRepository).getScheduledById(eq(""))
   }
 
   @Test

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.se.eduverse.viewmodel
 
 import com.github.se.eduverse.model.Scheduled
 import com.github.se.eduverse.model.ScheduledType
+import com.github.se.eduverse.repository.NotificationRepository
 import com.github.se.eduverse.repository.TimeTableRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -18,6 +19,7 @@ import org.mockito.kotlin.verify
 
 class TimeTableViewModelTest {
   private lateinit var timeTableRepository: TimeTableRepository
+  private lateinit var notificationRepository: NotificationRepository
   private lateinit var firebaseAuth: FirebaseAuth
   private lateinit var user: FirebaseUser
   private lateinit var timeTableViewModel: TimeTableViewModel
@@ -61,6 +63,7 @@ class TimeTableViewModelTest {
   @Before
   fun setUp() {
     timeTableRepository = mock(TimeTableRepository::class.java)
+    notificationRepository = mock(NotificationRepository::class.java)
     firebaseAuth = mock(FirebaseAuth::class.java)
     user = mock(FirebaseUser::class.java)
 
@@ -74,7 +77,8 @@ class TimeTableViewModelTest {
       callback(listOf(scheduled1, scheduled2))
     }
 
-    timeTableViewModel = TimeTableViewModel(timeTableRepository, firebaseAuth)
+    timeTableViewModel =
+        TimeTableViewModel(timeTableRepository, notificationRepository, firebaseAuth)
     timeTableViewModel.getWeek()
 
     // 3 because scheduled1 and scheduled2 are tuesday, represented by 3

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/TimeTableViewModelTest.kt
@@ -141,8 +141,8 @@ class TimeTableViewModelTest {
 
     timeTableViewModel.getWeek()
     timeTableViewModel.addScheduled(scheduled2)
-    val t = timeTableViewModel.table.value
     assertEquals(weekWithScheduled, timeTableViewModel.table.value)
+    verify(1) { notificationRepository.scheduleNotification(any()) }
   }
 
   @Test
@@ -155,6 +155,7 @@ class TimeTableViewModelTest {
     timeTableViewModel.updateScheduled(scheduled2.apply { name = "newName" })
     assertEquals("newName", scheduled2.name)
     assertEquals(weekWithScheduled, timeTableViewModel.table.value)
+    verify(1) { notificationRepository.scheduleNotification(any()) }
   }
 
   @Test
@@ -170,6 +171,7 @@ class TimeTableViewModelTest {
 
     timeTableViewModel.deleteScheduled(scheduled3)
     assertEquals(weekWithScheduled, timeTableViewModel.table.value)
+    verify(1) { notificationRepository.cancelNotification(any()) }
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ firebaseStorageKtx = "21.0.1"
 coreTesting = "2.1.0"
 junitKtx = "1.2.1"
 core = "1.46.0"
+workTesting = "2.8.1"
 
 [libraries]
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
@@ -131,6 +132,7 @@ firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage
 androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "coreTesting" }
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
 core = { group = "com.google.ar", name = "core", version.ref = "core" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workTesting" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR add the feature of opening the app when clicking on notifications.

When creating the notification, it is linked with an Intent that is used when launching MainActivity.

Upon creation, MainActivity checks if its Intent has the field isNotification set to true (by default the app is also launched with an intent, but it doesn't have fields). If no, everything happen as before but if yes, the LoadingScreen navigate the user to the correct screen (SignIn if no account is connected, DetailsEventScreen or DetailsTaskScreen otherwise)

There is also a new data class, NotificationData. It allows passing all necessary values to EduverseApp without overwhelming its signature. It will also be usefull if we create notifications in an other part of the app, as it will decrease repetition. 