### PR TITLE
Feature/documents to pdf conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           echo $DATA | base64 -di > app/google-services.json
 
+      - name: Get local.properties from secrets
+        run:
+          echo "${{secrets.LOCAL_PROPERTIES }}" > $GITHUB_WORKSPACE/local.properties
+
       - name: Prepare Custom Keystore
         env:
           BASE64_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
     val openAiApiKey = localProperties.getProperty("OPENAI_API_KEY") ?: ""
+    val convertApiKey = localProperties.getProperty("CONVERT_API_KEY") ?: ""
 
     defaultConfig {
         applicationId = "com.github.se.eduverse"
@@ -44,8 +45,9 @@ android {
             useSupportLibrary = true
         }
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
-        // Add the API key as a build config field so that it can be kept secret in the local.properties file and retrieved at runtime by the CI from the github secrets
+        // Add the API keys as a build config field so that it can be kept secret in the local.properties file and retrieved at runtime by the CI from the github secrets
         buildConfigField("String", "OPENAI_API_KEY", "\"${openAiApiKey}\"")
+        buildConfigField("String", "CONVERT_API_KEY", "\"${convertApiKey}\"")
     }
 
 

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterInstrumentationTest.kt
@@ -7,11 +7,13 @@ import android.net.Uri
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.repository.ConvertApiRepository
 import com.github.se.eduverse.repository.OpenAiRepository
 import com.github.se.eduverse.repository.PdfRepository
 import com.github.se.eduverse.repository.PdfRepositoryImpl
 import com.github.se.eduverse.viewmodel.PdfConverterViewModel
 import java.io.File
+import junit.framework.TestCase
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -29,13 +31,16 @@ class PdfConverterInstrumentationTest {
   private lateinit var openAiRepository: OpenAiRepository
   private lateinit var context: Context
   private lateinit var pdfConverterViewModel: PdfConverterViewModel
+  private lateinit var convertApiRepository: ConvertApiRepository
 
   @Before
   fun setUp() {
     context = ApplicationProvider.getApplicationContext()
     pdfRepository = PdfRepositoryImpl()
     openAiRepository = OpenAiRepository(OkHttpClient())
-    pdfConverterViewModel = PdfConverterViewModel(pdfRepository, openAiRepository)
+    convertApiRepository = ConvertApiRepository(OkHttpClient())
+    pdfConverterViewModel =
+        PdfConverterViewModel(pdfRepository, openAiRepository, convertApiRepository)
   }
 
   @Test
@@ -163,5 +168,18 @@ class PdfConverterInstrumentationTest {
     val extractedText = pdfRepository.readTextFromPdfFile(Uri.fromFile(pdfFile), context)
     assertEquals(text.replace(" ", ""), extractedText.replace(" ", ""))
     pdfFile.delete()
+  }
+
+  @Test
+  fun testGetTempFileFromUri() {
+    val tempFile = File.createTempFile("test", ".docx")
+    val uri = Uri.fromFile(tempFile)
+
+    val result = pdfRepository.getTempFileFromUri(uri, context)
+
+    TestCase.assertTrue(result.exists())
+    TestCase.assertTrue(result.name.endsWith(".docx"))
+    tempFile.delete()
+    result.delete()
   }
 }

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.repository.ConvertApiRepository
 import com.github.se.eduverse.repository.OpenAiRepository
 import com.github.se.eduverse.repository.PdfRepository
 import com.github.se.eduverse.ui.converter.PdfConverterOption
@@ -44,6 +45,7 @@ class PdfConverterScreenTest {
   private lateinit var pdfConverterViewModel: PdfConverterViewModel
   private lateinit var mockPdfRepository: PdfRepository
   private lateinit var mockOpenAiRepository: OpenAiRepository
+  private lateinit var mockConvertApiRepository: ConvertApiRepository
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -54,7 +56,9 @@ class PdfConverterScreenTest {
     mockNavigationActions = mock(NavigationActions::class.java)
     mockPdfRepository = mock(PdfRepository::class.java)
     mockOpenAiRepository = mock(OpenAiRepository::class.java)
-    pdfConverterViewModel = PdfConverterViewModel(mockPdfRepository, mockOpenAiRepository)
+    mockConvertApiRepository = mock(ConvertApiRepository::class.java)
+    pdfConverterViewModel =
+        PdfConverterViewModel(mockPdfRepository, mockOpenAiRepository, mockConvertApiRepository)
 
     `when`(mockNavigationActions.currentRoute()).thenReturn(Screen.PDF_CONVERTER)
   }
@@ -107,10 +111,6 @@ class PdfConverterScreenTest {
   @Test
   fun notImplementedOptionsClickDoesNotChangeGenerationState() {
     composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).performClick()
-    assertEquals(
-        PdfConverterViewModel.PdfGenerationState.Ready,
-        pdfConverterViewModel.pdfGenerationState.value)
     composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).performClick()
     assertEquals(
         PdfConverterViewModel.PdfGenerationState.Ready,
@@ -219,6 +219,22 @@ class PdfConverterScreenTest {
     Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
         .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
     composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+  }
+
+  @Test
+  fun clickingDocumentToPdfOption_launchesFilePicker() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-docx-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+    composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).performClick()
     composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
     composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
     composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()

--- a/app/src/main/java/com/github/se/eduverse/api/ConvertApi.kt
+++ b/app/src/main/java/com/github/se/eduverse/api/ConvertApi.kt
@@ -1,0 +1,20 @@
+package com.github.se.eduverse.api
+
+import com.squareup.moshi.Json
+
+// Data class to encapsulate the response from the ConvertAPI service
+data class ConvertApiResponse(@Json(name = "Files") val files: List<ConvertedFile>)
+
+// Data class to encapsulate the converted file from the ConvertAPI service (only keeps the Url
+// field because that's all we need when processing the response)
+data class ConvertedFile(@Json(name = "Url") val url: String)
+
+// List of supported file types for conversion with the ConvertAPI service
+val SUPPORTED_CONVERSION_TYPES =
+    listOf("docx", "doc", "pptx", "ppt", "xls", "xlsx", "pages", "numbers", "key", "csv")
+
+// These exceptions are defined so that it's clearer when debugging which api call resulted in the
+// failure of the whole conversion process
+class FileConversionException(message: String, cause: Throwable) : Exception(message, cause)
+
+class FileDownloadException(message: String, cause: Throwable) : Exception(message, cause)

--- a/app/src/main/java/com/github/se/eduverse/repository/ConvertApiRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/ConvertApiRepository.kt
@@ -1,0 +1,124 @@
+package com.github.se.eduverse.repository
+
+import com.github.se.eduverse.BuildConfig
+import com.github.se.eduverse.api.ConvertApiResponse
+import com.github.se.eduverse.api.FileConversionException
+import com.github.se.eduverse.api.FileDownloadException
+import com.github.se.eduverse.api.SUPPORTED_CONVERSION_TYPES
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.File
+import java.io.FileOutputStream
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+
+open class ConvertApiRepository(private val client: OkHttpClient) {
+  private val apiKey = BuildConfig.CONVERT_API_KEY
+  private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+  private val responseAdapter = moshi.adapter(ConvertApiResponse::class.java)
+
+  /**
+   * Converts the given file to a PDF file using the ConvertAPI service
+   *
+   * @param file The file to convert
+   * @param pdfName The name that the result PDF file should have
+   * @return The converted PDF file if successful
+   * @throws FileConversionException If the conversion of the file fails
+   * @throws FileDownloadException If the download of the converted PDF file fails
+   * @throws IllegalArgumentException If the file type is not supported for conversion
+   */
+  open fun convertToPdf(file: File, pdfName: String): File? {
+    val fileType = file.extension
+
+    try {
+      // Check if the file type is supported for conversion
+      if (fileType !in SUPPORTED_CONVERSION_TYPES) {
+        throw IllegalArgumentException("Unsupported file type: $fileType")
+      }
+
+      val url = "https://v2.convertapi.com/convert/$fileType/to/pdf"
+
+      val requestBody =
+          MultipartBody.Builder()
+              .setType(MultipartBody.FORM)
+              .addFormDataPart(
+                  "File", file.name, file.asRequestBody()) // Upload the file to convert
+              .addFormDataPart(
+                  "StoreFile",
+                  "true") // We store the file on the server because otherwise the result file data
+              // is entirely provided in the response body which can lead to out of
+              // memory errors if the file is too large, and with the url we download
+              // the file in a streamed manner avoiding memory issues
+              .build()
+
+      val request =
+          Request.Builder()
+              .url(url)
+              .addHeader("Authorization", "Bearer $apiKey")
+              .addHeader("accept", "application/json")
+              .post(requestBody)
+              .build()
+
+      // We use synchronous api calls for the conversion and the download because the latter depends
+      // on the former's result and making the calls synchronous avoids callback hell and makes the
+      // code easier to read. Also the blocking nature of the calls is dealt with in the viewmodel
+      // by running the conversion in a background thread which makes it as though the calls were
+      // asynchronous
+      val response = client.newCall(request).execute()
+      if (!response.isSuccessful) {
+        throw Exception("Unsuccessful convert respsonse: $response")
+      }
+
+      response.body?.let { body ->
+        val convertApiResponse = responseAdapter.fromJson(body.string())
+        val fileUrl =
+            convertApiResponse?.files?.firstOrNull()?.url // Get the URL of the converted PDF file
+        if (fileUrl != null) {
+          file.delete() // Delete the original file (which is a temp copy file and not needed
+          // anymore once converted)
+          return downloadPdfFile(
+              fileUrl, pdfName) // Download the converted PDF file and return it if successful
+        } else {
+          throw Exception("File URL not found in convert response")
+        }
+      } ?: throw Exception("Empty convert response body")
+    } catch (e: Exception) {
+      file.delete()
+      if (e is FileDownloadException || e is IllegalArgumentException) {
+        throw e
+      } else {
+        throw FileConversionException("Failed to convert file to PDF", e)
+      }
+    }
+  }
+
+  /**
+   * Helper function to download the converted PDF file when the conversion is successful
+   *
+   * @param fileUrl The URL of the converted PDF file
+   * @param pdfName The name that the result PDF file should have
+   * @return The downloaded PDF file
+   * @throws FileDownloadException If the download fails
+   */
+  private fun downloadPdfFile(fileUrl: String, pdfName: String): File? {
+    val pdfFile = File.createTempFile(pdfName, ".pdf")
+    try {
+      val request = Request.Builder().url(fileUrl).build()
+
+      val response = client.newCall(request).execute()
+      if (!response.isSuccessful) throw Exception("Unsuccessful download response: $response")
+
+      val inputStream =
+          response.body?.byteStream() ?: throw Exception("Empty download response body")
+      val outputStream = FileOutputStream(pdfFile)
+
+      inputStream.use { input -> outputStream.use { output -> input.copyTo(output) } }
+      return pdfFile
+    } catch (e: Exception) {
+      pdfFile.delete()
+      throw FileDownloadException("Failed to download PDF file", e)
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/eduverse/repository/PdfRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/PdfRepository.kt
@@ -35,6 +35,8 @@ interface PdfRepository {
   fun readTextFromPdfFile(pdfUri: Uri?, context: Context, limit: Int = 0): String
 
   fun writeTextToPdf(text: String): PdfDocument
+
+  fun getTempFileFromUri(uri: Uri?, context: Context): File
 }
 
 class PdfRepositoryImpl : PdfRepository {
@@ -126,7 +128,7 @@ class PdfRepositoryImpl : PdfRepository {
       onFailure: (e: Exception) -> Unit
   ) {
     try {
-      val file = createUniqueFile(destinationDirectory, pdfFileName + ".pdf")
+      val file = createUniqueFile(destinationDirectory, "$pdfFileName.pdf")
       pdfFile.copyTo(file)
       deleteTempPdfFile(pdfFile)
       onSuccess(file)
@@ -249,6 +251,27 @@ class PdfRepositoryImpl : PdfRepository {
       return pdfDocument
     } catch (e: Exception) {
       Log.e("writeTextToPdf", "Failed to write text to pdf", e)
+      throw e
+    }
+  }
+
+  /**
+   * Get a temporary file from the given URI
+   *
+   * @param uri The URI of the file to get
+   * @param context The context of the application
+   * @return The temporary file created from the URI
+   * @throws Exception If an error occurs during the process
+   */
+  override fun getTempFileFromUri(uri: Uri?, context: Context): File {
+    try {
+      val inputStream = context.contentResolver.openInputStream(uri!!)
+      val documentType = uri.path?.substringAfterLast(".") ?: ""
+      val tempFile = File.createTempFile("tempDocument", ".$documentType")
+      tempFile.outputStream().use { outputStream -> inputStream?.copyTo(outputStream) }
+      return tempFile
+    } catch (e: Exception) {
+      Log.e("getTempFileFromUri", "Failed to get temp file from uri", e)
       throw e
     }
   }

--- a/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/converter/PdfConverter.kt
@@ -120,7 +120,7 @@ fun PdfConverterScreen(
                         icon = Icons.Default.PictureAsPdf,
                         onClick = {
                           currentPdfConverterOption = PdfConverterOption.DOCUMENT_TO_PDF
-                          Toast.makeText(context, "Not available yet", Toast.LENGTH_LONG).show()
+                          filePickerLauncher.launch(arrayOf("*/*"))
                         },
                         optionEnabled =
                             pdfConversionState.value ==

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/PdfConverterViewModel.kt
@@ -16,6 +16,7 @@ import com.github.se.eduverse.ui.converter.PdfConverterOption
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -120,6 +121,7 @@ class PdfConverterViewModel(
               PdfConverterOption.NONE ->
                   throw Exception("No converter option selected") // Should never happen
             }
+            delay(3000) // Simulate a delay to show the progress indicator(for testing purposes)
             // Simulate a delay to show the progress indicator(for testing purposes)
             currentFile?.let { file ->
               _pdfGenerationState.value = PdfGenerationState.Success(file)

--- a/app/src/test/java/com/github/se/eduverse/repository/ConvertApiRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/ConvertApiRepositoryTest.kt
@@ -1,0 +1,163 @@
+package com.github.se.eduverse.repository
+
+import com.github.se.eduverse.api.FileConversionException
+import com.github.se.eduverse.api.FileDownloadException
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ConvertApiRepositoryTest {
+
+  private lateinit var convertApiRepository: ConvertApiRepository
+  private lateinit var mockClient: OkHttpClient
+  private lateinit var mockConversionCall: Call
+  private lateinit var mockDownloadCall: Call
+  private lateinit var mockConversionResponse: Response
+  private lateinit var mockDownloadResponse: Response
+
+  @Before
+  fun setUp() {
+    mockClient = mockk()
+    mockConversionCall = mockk()
+    mockDownloadCall = mockk()
+    mockConversionResponse = mockk()
+    mockDownloadResponse = mockk()
+
+    convertApiRepository = ConvertApiRepository(mockClient)
+
+    every { mockClient.newCall(any()) } answers
+        {
+          val request = it.invocation.args[0] as Request
+          if (request.url.toString().contains("/convert/")) mockConversionCall else mockDownloadCall
+        }
+    every { mockConversionCall.execute() } returns mockConversionResponse
+    every { mockDownloadCall.execute() } returns mockDownloadResponse
+  }
+
+  @Test
+  fun `convertToPdf should throw IllegalArgumentException for unsupported file type`() {
+    val file = File.createTempFile("test", ".pdf")
+    val pdfName = "testPdf"
+    assertThrows(IllegalArgumentException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should throw FileConversionException when response is not successful`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+
+    every { mockConversionResponse.isSuccessful } returns false
+
+    assertThrows(FileConversionException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should throw FileConversionException when response body is empty`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+
+    every { mockConversionResponse.isSuccessful } returns true
+    every { mockConversionResponse.body } returns null
+
+    assertThrows(FileConversionException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should throw FileConversionException when file URL is not found in response`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+    val mockResponseBody = """{"Files":[]}""".toResponseBody("application/json".toMediaType())
+
+    every { mockConversionResponse.isSuccessful } returns true
+    every { mockConversionResponse.body } returns mockResponseBody
+    assertThrows(FileConversionException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should throw FileDownloadException when download response is not successful`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+
+    val mockConversionResponseBody =
+        """{"Files":[{"Url":"https://example.com/file.pdf"}]}"""
+            .toResponseBody("application/json".toMediaType())
+
+    every { mockConversionResponse.isSuccessful } returns true
+    every { mockConversionResponse.body } returns mockConversionResponseBody
+
+    every { mockDownloadResponse.isSuccessful } returns false
+
+    assertThrows(FileDownloadException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should throw FileDownloadException when download response body is empty`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+
+    val mockConversionResponseBody =
+        """{"Files":[{"Url":"https://example.com/file.pdf"}]}"""
+            .toResponseBody("application/json".toMediaType())
+
+    every { mockConversionResponse.isSuccessful } returns true
+    every { mockConversionResponse.body } returns mockConversionResponseBody
+
+    every { mockDownloadResponse.isSuccessful } returns true
+    every { mockDownloadResponse.body } returns null
+
+    assertThrows(FileDownloadException::class.java) {
+      convertApiRepository.convertToPdf(file, pdfName)
+    }
+    file.delete()
+  }
+
+  @Test
+  fun `convertToPdf should return converted PDF file when successful`() {
+    val file = File.createTempFile("test", ".docx")
+    val pdfName = "testPdf"
+
+    val mockConversionResponseBody =
+        """{"Files":[{"Url":"https://example.com/file.pdf"}]}"""
+            .toResponseBody("application/json".toMediaType())
+
+    every { mockConversionResponse.isSuccessful } returns true
+    every { mockConversionResponse.body } returns mockConversionResponseBody
+
+    val mockDownloadResponseBody =
+        "Mock PDF content".toResponseBody("application/pdf".toMediaType())
+
+    every { mockDownloadResponse.isSuccessful } returns true
+    every { mockDownloadResponse.body } returns mockDownloadResponseBody
+
+    val result = convertApiRepository.convertToPdf(file, pdfName)
+
+    assertNotNull(result)
+    assertTrue(result!!.exists())
+    assertTrue(result.name.startsWith(pdfName) && result.extension == "pdf")
+    file.delete()
+    result.delete()
+  }
+}


### PR DESCRIPTION
This PR implements the document to pdf converter tool which allows users to convert different types of documents (docx, pptx, xlsx, pages, csv, etc) frequently used by students to pdf. This tool can be very useful for students since they often produce their deliverables on one of the mentioned documents and are also often required to hand in the final result in pdf format. The conversion is performed using ConvertApi, and upon successful conversion the generated pdf file is downloaded and stored in the local device storage.

### Checklist:
- [x] Add ConvertApi key to the BuildConfig fields in `app/build.gradle.kts` 
- [x] Add ConvertApi key to github secrets
- [x] Add `ConvertApi` file to define the artifacts needed in the implementation of the functions to interact with the api
- [x] Implement the functions that handle the conversion process in `ConvertApiRepository`
- [x] Implement tests for `ConvertApiRepository` functions
- [x] Update `generatePdf` function in `PdfConverterViewModel` to handle document to pdf option
- [x] Update `PdfConverterViewModelTest` to test new code
- [x] Update `PdfConverterScreen` to be able to launch the conversion on doc to pdf option click
- [x] Add `getTempFileFromUri` function to `PdfRepository` to be able to create a temp file from the uri of the file to convert which will be uploaded to ConvertApi for conversion
- [x] Test `getTempFileFromUri` in `PdfConverterInstrumentationTest` (because we need the android environment to be able to create a uri from a file and test that the fumction correctly creates the temp file from the uri)
- [x] Test that the click on the doc to pdf card launches the file picker in `PdfConverterScreenTest` 
- [x] Update `build.yml` to get `LOCAL_PROPERTIES` from github secrets
- [x] Document code
- [x] Format Code with Ktfmt  