### PR TITLE
Fix/add explanations to pdf converter

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/converter/PdfConverterScreenTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.api.SUPPORTED_CONVERSION_TYPES
 import com.github.se.eduverse.repository.ConvertApiRepository
 import com.github.se.eduverse.repository.OpenAiRepository
 import com.github.se.eduverse.repository.PdfRepository
@@ -85,170 +86,36 @@ class PdfConverterScreenTest {
     composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name)
-        .assertTextEquals("Text to PDF")
+        .assertTextContains("Text to PDF")
+        .assertTextContains("Converts a .txt file to PDF")
     composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name)
-        .assertTextEquals("Image to PDF")
+        .assertTextContains("Image to PDF")
+        .assertTextContains("Converts an image to PDF")
     composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).assertIsDisplayed()
     composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).assertHasClickAction()
     composeTestRule
         .onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name)
-        .assertTextEquals("Doc to PDF")
+        .assertTextContains("Doc to PDF")
+        .assertTextContains("Converts a document to PDF")
     composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertIsDisplayed()
     composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).assertHasClickAction()
     composeTestRule
         .onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name)
-        .assertTextEquals("Summarize file")
+        .assertTextContains("Summarize file")
+        .assertTextContains("Generates a summary of a file")
     composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertIsDisplayed()
     composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).assertHasClickAction()
     composeTestRule
         .onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name)
-        .assertTextEquals("Extract text")
+        .assertTextContains("Extract text")
+        .assertTextContains("Extracts text from an image")
     composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
   }
 
   @Test
-  fun clickingTextToPdfOption_launchesFilePicker() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-document-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-
-    composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
-    assertEquals(
-        PdfConverterViewModel.PdfGenerationState.Ready,
-        pdfConverterViewModel.pdfGenerationState.value)
-  }
-
-  @Test
-  fun pdfGenerationStateIsSetToReadyOnError() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-image-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    `when`(mockPdfRepository.convertImageToPdf(any(), any())).then { throw Exception() }
-    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
-    assertEquals("test.pdf", pdfConverterViewModel.newFileName.value)
-    assertEquals(
-        PdfConverterViewModel.PdfGenerationState.Ready,
-        pdfConverterViewModel.pdfGenerationState.value)
-  }
-
-  @Test
-  fun pdfGenerationStateIsSetToReadyOnSuccess() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-image-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    `when`(mockPdfRepository.convertImageToPdf(any(), any())).thenReturn(PdfDocument())
-    `when`(mockPdfRepository.writePdfDocumentToTempFile(any(), any())).thenReturn(File("test.pdf"))
-    `when`(mockPdfRepository.savePdfToDevice(any(), any(), any(), any(), any())).then {
-      assertEquals(
-          pdfConverterViewModel.pdfGenerationState.value,
-          PdfConverterViewModel.PdfGenerationState.Ready)
-    }
-    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
-    assertEquals("test.pdf", pdfConverterViewModel.newFileName.value)
-  }
-
-  @Test
-  fun clickingImageToPdfOption_launchesFilePicker() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-image-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag("loadingIndicator").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("abortButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("abortButton").performClick()
-    assertEquals(
-        PdfConverterViewModel.PdfGenerationState.Aborted,
-        pdfConverterViewModel.pdfGenerationState.value)
-  }
-
-  @Test
-  fun clickingSummarizeFileOption_launchesFilePicker() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-pdf-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-  }
-
-  @Test
-  fun clickingDocumentToPdfOption_launchesFilePicker() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-docx-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-  }
-
-  @Test
-  fun clickingExtractTextOption_launchesFilePicker() {
-    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
-    // Set up the activity result for the intent
-    // Simulate the file picker intent
-    val expectedUri = Uri.parse("content://test-image-uri")
-    val resultIntent = Intent().apply { data = expectedUri }
-    Intent().apply { data = expectedUri }
-    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
-        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
-    composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).performClick()
-    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
-    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
-  }
-
-  @Test
-  fun testPdfNameInputDialog() {
+  fun testPdfNameInputDialog_isCorrectlyDisplayed() {
     composeTestRule.setContent {
       PdfNameInputDialog(pdfFileName = "test.pdf", onDismiss = {}, onConfirm = {})
     }
@@ -274,18 +141,7 @@ class PdfConverterScreenTest {
   }
 
   @Test
-  fun testPdfNameInputDialog_confirm() {
-    var confirmedFileName = ""
-    composeTestRule.setContent {
-      PdfNameInputDialog(
-          pdfFileName = "test.pdf", onDismiss = {}, onConfirm = { confirmedFileName = it })
-    }
-    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
-    assert(confirmedFileName == "test.pdf")
-  }
-
-  @Test
-  fun testPdfNameInputDialog_confirmCallsOnConfirm() {
+  fun testPdfNameInputDialog_confirmButtonWithInputText() {
     var confirmedFileName = ""
     composeTestRule.setContent {
       PdfNameInputDialog(pdfFileName = "", onDismiss = {}, onConfirm = { confirmedFileName = it })
@@ -319,14 +175,198 @@ class PdfConverterScreenTest {
   }
 
   @Test
-  fun filePickerWithNullUri_showsToastMessage() {
+  fun clickingTextToPdfOption_correctlyDisplaysInfoWindow() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowTitle").assertTextEquals("Text to PDF converter")
+    composeTestRule
+        .onNodeWithTag("infoWindowText")
+        .assertTextEquals("Select a .txt file to convert to PDF")
+    composeTestRule.onNodeWithTag("infoWindowDismissButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowDismissButton").assertTextContains("Cancel")
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").assertTextContains("Select file")
+    composeTestRule.onNodeWithTag("infoWindowDismissButton").performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun clickingImageToPdfOption_correctlyDisplaysInfoWindow() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowTitle").assertTextEquals("Image to PDF converter")
+    composeTestRule
+        .onNodeWithTag("infoWindowText")
+        .assertTextEquals("Select an image to convert to PDF")
+  }
+
+  @Test
+  fun clickingSummarizeFileOption_correctlyDisplaysInfoWindow() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.SUMMARIZE_FILE.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowTitle").assertTextEquals("Pdf file summarizer")
+    composeTestRule
+        .onNodeWithTag("infoWindowText")
+        .assertTextEquals(
+            "Select a PDF file to summarize. The summary will be generated in a PDF file")
+  }
+
+  @Test
+  fun clickingDocumentToPdfOption_correctlyDisplaysInfoWindow() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowTitle").assertTextEquals("Document to PDF converter")
+    composeTestRule
+        .onNodeWithTag("infoWindowText")
+        .assertTextEquals(
+            "Select a document to convert to PDF. Supported document types are: ${
+      SUPPORTED_CONVERSION_TYPES.joinToString(
+        ", "
+      )
+    }")
+  }
+
+  @Test
+  fun clickingExtractTextOption_correctlyDisplaysInfoWindow() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.EXTRACT_TEXT.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("infoWindowTitle").assertTextEquals("Text extractor")
+    composeTestRule
+        .onNodeWithTag("infoWindowText")
+        .assertTextEquals(
+            "Select an image to extract text from. Make sure the selected image contains text. The extracted text will be generated in a PDF file")
+  }
+
+  @Test
+  fun selectSourceFileDialogIsCorrectlyDisplayed() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("selectSourceFileDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("appFoldersButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("appFoldersButton").assertTextContains("App folders")
+    composeTestRule.onNodeWithTag("appFoldersButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("deviceStorageButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("deviceStorageButton").assertTextContains("Device storage")
+    composeTestRule.onNodeWithTag("deviceStorageButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("selectSourceFileDismissButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("selectSourceFileDismissButton").assertTextContains("Cancel")
+    composeTestRule.onNodeWithTag("selectSourceFileDismissButton").performClick()
+    composeTestRule.onNodeWithTag("selectSourceFileDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun clickingDeviceStorageButtonInSelectSourceFileDialog_launchesFilePicker() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-document-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+    composeTestRule.onNodeWithTag(PdfConverterOption.DOCUMENT_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("deviceStorageButton").performClick()
+    composeTestRule.onNodeWithTag("selectSourceFileDialog").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dismissCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun pdfGenerationStateIsSetToReadyOnSuccess() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-image-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+    `when`(mockPdfRepository.convertImageToPdf(any(), any())).thenReturn(PdfDocument())
+    `when`(mockPdfRepository.writePdfDocumentToTempFile(any(), any())).thenReturn(File("test.pdf"))
+    `when`(mockPdfRepository.savePdfToDevice(any(), any(), any(), any(), any())).then {
+      assertEquals(
+          pdfConverterViewModel.pdfGenerationState.value,
+          PdfConverterViewModel.PdfGenerationState.Ready)
+    }
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("deviceStorageButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    assertEquals("test.pdf", pdfConverterViewModel.newFileName.value)
+  }
+
+  @Test
+  fun pdfGenerationStateIsSetToReadyOnError() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-image-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+    `when`(mockPdfRepository.convertImageToPdf(any(), any())).then { throw Exception() }
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("deviceStorageButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    assertEquals("test.pdf", pdfConverterViewModel.newFileName.value)
+    assertEquals(
+        PdfConverterViewModel.PdfGenerationState.Ready,
+        pdfConverterViewModel.pdfGenerationState.value)
+  }
+
+  @Test
+  fun testAbortPdfGeneration_setsPdfGenerationStateToAborted() {
+    composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
+    // Set up the activity result for the intent
+    // Simulate the file picker intent
+    val expectedUri = Uri.parse("content://test-image-uri")
+    val resultIntent = Intent().apply { data = expectedUri }
+    Intent().apply { data = expectedUri }
+    Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
+        .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent))
+    composeTestRule.onNodeWithTag(PdfConverterOption.IMAGE_TO_PDF.name).performClick()
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("deviceStorageButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("pdfNameInput").performTextInput("test.pdf")
+    composeTestRule.onNodeWithTag("confirmCreatePdfButton").performClick()
+    composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("loadingIndicator").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("abortButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("abortButton").performClick()
+    assertEquals(
+        PdfConverterViewModel.PdfGenerationState.Aborted,
+        pdfConverterViewModel.pdfGenerationState.value)
+  }
+
+  @Test
+  fun testFilePickerWithNullUri_resultsInCorrectBehavior() {
     composeTestRule.setContent { PdfConverterScreen(mockNavigationActions, pdfConverterViewModel) }
 
     Intents.intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
         .respondWith(Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null))
 
     composeTestRule.onNodeWithTag(PdfConverterOption.TEXT_TO_PDF.name).performClick()
-
+    composeTestRule.onNodeWithTag("infoWindowConfirmButton").performClick()
+    composeTestRule.onNodeWithTag("deviceStorageButton").performClick()
     composeTestRule.onNodeWithTag("pdfNameInputDialog").assertIsNotDisplayed()
+    assertEquals(
+        PdfConverterViewModel.PdfGenerationState.Ready,
+        pdfConverterViewModel.pdfGenerationState.value)
   }
 }


### PR DESCRIPTION
This PR improves the UX of the pdf converter feature, it:
- Adds a brief description of what each tool does to `OptionCard`
- Adds an `InfoWindow` composable to `PdfConverter`, which is displayed on option click and informs the user what type of input file he needs to select for the clicked option and allows him to either proceed to the selection of the file or cancel
- Adds the possibility of selecting the input file from either the device's storage (which was the only option) or the app's folders (logic not yet implemented), the choice is made by the user through the `SelectSourceFileDialog` which has two buttons `Device storage` and `App Folders` 

<img width="358" alt="Capture d’écran 2024-12-02 à 16 59 23" src="https://github.com/user-attachments/assets/33b90320-3666-4640-a5f1-bb6effdb4246">

<img width="361" alt="Capture d’écran 2024-12-02 à 16 59 40" src="https://github.com/user-attachments/assets/b4199554-f009-4a6a-9fe3-f6825e991902">

<img width="361" alt="Capture d’écran 2024-12-02 à 16 59 57" src="https://github.com/user-attachments/assets/c432fbf0-8e9e-42c8-9bde-58639900c0f8">



### Checklist:
- [x] Add a description to the different instances of `OptionCard` in `PdfConverter`
- [x] Implement `InfoWindow` in `PdfConverter`
- [x] Update the on click behavior of the option cards to set `showInfoWindow` to true and add the logic to display `InfoWindow` in `PdfConverterScreen` when `showInfoWindow` is true
- [x] Implement `SelectSourceFileDialog` in `PdfConverter`
- [x] Update the on click button of the `confirmButton` of `InfoWindow` so that it sets `showSelectSourceDialog` to true and add the logic to display `SelectSourceFileDialog` in `PdfConverterScreen` when `showSelectSourceDialog` is true
- [x] Add `inputFileMIMEType` to `PdfConverterScreen`, a `MutableStateFlow` to be set on option card click to the appropriate MIME type and provided as input to the `filePickerLauncher` when it's launched by clicking on the `Device to Storage` button
- [x] Update the tests in `PdfConverterTest` to match the new user flow 
- [x] Add tests in `PdfConverterTest` for the newly added composables 
- [x] Document new code 
- [x] Format code with Ktfmt
