### PR TITLE
Add history to the search bar

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
@@ -72,6 +72,14 @@ class FakeProfileRepository : ProfileRepository {
     TODO("Not yet implemented")
   }
 
+  override suspend fun loadSearchHistory(userId: String, limit: Int): List<Profile> {
+    TODO("Not yet implemented")
+  }
+
+  override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
+    TODO("Not yet implemented")
+  }
+
   override suspend fun createProfile(
       userId: String,
       defaultUsername: String,

--- a/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
@@ -76,9 +76,7 @@ class FakeProfileRepository : ProfileRepository {
     return emptyList()
   }
 
-  override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
-
-  }
+  override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {}
 
   override suspend fun createProfile(
       userId: String,

--- a/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
@@ -77,7 +77,7 @@ class FakeProfileRepository : ProfileRepository {
   }
 
   override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
-    TODO("Not yet implemented")
+
   }
 
   override suspend fun createProfile(

--- a/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/fake/FakeProfileRepository.kt
@@ -73,7 +73,7 @@ class FakeProfileRepository : ProfileRepository {
   }
 
   override suspend fun loadSearchHistory(userId: String, limit: Int): List<Profile> {
-    TODO("Not yet implemented")
+    return emptyList()
   }
 
   override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/search/SearchProfileTest.kt
@@ -9,13 +9,16 @@ import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class SearchProfileScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
@@ -151,6 +154,19 @@ class SearchProfileScreenTest {
 
     composeTestRule.onNodeWithTag(TAG_SEARCH_FIELD).performTextInput("TestQuery")
     assert(searchQuery == "testquery") { "Search query should be converted to lowercase" }
+  }
+
+  @Test
+  fun emptyQuery_displaysHistory() = runTest {
+    whenever(mockRepository.loadSearchHistory(any(), any())).thenReturn(listOf(Profile(id = "id")))
+    val vm = ProfileViewModel(mockRepository)
+    composeTestRule.setContent {
+      SearchProfileScreen(
+          navigationActions = mockNavigationActions, viewModel = vm, currentUserId = "user")
+    }
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag(TAG_PROFILE_ITEM + "_id").assertIsDisplayed()
   }
 }
 

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SavedScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SavedScreenTest.kt
@@ -63,6 +63,14 @@ class FakeProfileRepository : ProfileRepository {
 
   override suspend fun searchProfiles(query: String, limit: Int): List<Profile> = emptyList()
 
+  override suspend fun loadSearchHistory(userId: String, limit: Int): List<Profile> {
+    TODO("Not yet implemented")
+  }
+
+  override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
+    TODO("Not yet implemented")
+  }
+
   override suspend fun createProfile(
       userId: String,
       defaultUsername: String,

--- a/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/github/se/eduverse/repository/ProfileRepository.kt
@@ -220,43 +220,40 @@ open class ProfileRepositoryImpl(
     }
   }
 
-    override suspend fun loadSearchHistory(userId: String, limit: Int): List<Profile> {
-        return try {
-            val listId = usersCollection
-                .document(userId)
-                .collection("searchHistory")
-                .orderBy("timestamp", Query.Direction.DESCENDING)
-                .limit(limit.toLong())
-                .get()
-                .await()
-                .documents
-                .mapNotNull {
-                    it.getString("id")
-                }.distinct()
-            profilesCollection
-                .whereIn(FieldPath.documentId(), listId)
-                .get()
-                .await()
-                .documents
-                .mapNotNull { it.toObject(Profile::class.java) }
-        } catch (e: Exception) {
-            Log.e("LOAD_HISTORY", "Failed to load search history: ${e.message}")
-            emptyList()
-        }
+  override suspend fun loadSearchHistory(userId: String, limit: Int): List<Profile> {
+    return try {
+      val listId =
+          usersCollection
+              .document(userId)
+              .collection("searchHistory")
+              .orderBy("timestamp", Query.Direction.DESCENDING)
+              .limit(limit.toLong())
+              .get()
+              .await()
+              .documents
+              .mapNotNull { it.getString("id") }
+              .distinct()
+      profilesCollection
+          .whereIn(FieldPath.documentId(), listId)
+          .get()
+          .await()
+          .documents
+          .mapNotNull { it.toObject(Profile::class.java) }
+    } catch (e: Exception) {
+      Log.e("LOAD_HISTORY", "Failed to load search history: ${e.message}")
+      emptyList()
     }
+  }
 
-    override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
-        usersCollection
-            .document(userId)
-            .collection("searchHistory")
-            .add(hashMapOf(
-                "timestamp" to System.currentTimeMillis(),
-                "id" to searchedProfileId
-            ))
-            .await()
-    }
+  override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
+    usersCollection
+        .document(userId)
+        .collection("searchHistory")
+        .add(hashMapOf("timestamp" to System.currentTimeMillis(), "id" to searchedProfileId))
+        .await()
+  }
 
-    override suspend fun createProfile(
+  override suspend fun createProfile(
       userId: String,
       defaultUsername: String,
       photoUrl: String

--- a/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/SearchProfileScreen.kt
@@ -26,6 +26,7 @@ import com.github.se.eduverse.model.Profile
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
+import com.google.firebase.auth.FirebaseAuth
 
 const val TAG_SEARCH_FIELD = "search_field"
 const val TAG_LOADING_INDICATOR = "loading_indicator"
@@ -40,9 +41,15 @@ const val TAG_PROFILE_STATS = "profile_stats"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchProfileScreen(navigationActions: NavigationActions, viewModel: ProfileViewModel) {
+fun SearchProfileScreen(
+    navigationActions: NavigationActions,
+    viewModel: ProfileViewModel,
+    currentUserId: String? = FirebaseAuth.getInstance().currentUser?.uid
+) {
   var searchQuery by remember { mutableStateOf("") }
   val searchState by viewModel.searchState.collectAsState()
+
+  LaunchedEffect(Unit) { viewModel.loadSearchHistory(currentUserId) }
 
   Scaffold(
       topBar = {
@@ -110,7 +117,12 @@ fun SearchProfileScreen(navigationActions: NavigationActions, viewModel: Profile
                       items(items = state.profiles, key = { it.id }) { profile ->
                         ProfileSearchItem(
                             profile = profile,
-                            onClick = { navigationActions.navigateToUserProfile(profile.id) })
+                            onClick = {
+                              if (currentUserId != null) {
+                                viewModel.addProfileToHistory(currentUserId, profile.id)
+                              }
+                              navigationActions.navigateToUserProfile(profile.id)
+                            })
                       }
                     }
               }

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
@@ -189,15 +189,20 @@ open class ProfileViewModel(open val repository: ProfileRepository) : ViewModel(
     if (userId == null) return
 
     searchJob?.cancel()
-    searchJob = viewModelScope.launch {
-      _searchState.value = SearchProfileState.Loading
-      try {
-        val results = repository.loadSearchHistory(userId)
-        _searchState.value = SearchProfileState.Success(results)
-      } catch (e: Exception) {
-        _searchState.value = SearchProfileState.Error(e.message ?: "Load history failed")
-      }
-    }
+    searchJob =
+        viewModelScope.launch {
+          _searchState.value = SearchProfileState.Loading
+          try {
+            val results = repository.loadSearchHistory(userId)
+            if (results.isEmpty()) {
+              _searchState.value = SearchProfileState.Idle
+            } else {
+              _searchState.value = SearchProfileState.Success(results)
+            }
+          } catch (e: Exception) {
+            _searchState.value = SearchProfileState.Error(e.message ?: "Load history failed")
+          }
+        }
   }
 
   open fun addProfileToHistory(userId: String, searchedProfileId: String) {

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.room.util.query
 import com.github.se.eduverse.model.Profile
 import com.github.se.eduverse.model.Publication
 import com.github.se.eduverse.repository.ProfileRepository
@@ -182,6 +183,21 @@ open class ProfileViewModel(open val repository: ProfileRepository) : ViewModel(
             _searchState.value = SearchProfileState.Error(e.message ?: "Search failed")
           }
         }
+  }
+
+  open fun loadSearchHistory(userId: String? = FirebaseAuth.getInstance().currentUser?.uid) {
+    if (userId == null) return
+
+    searchJob?.cancel()
+    searchJob = viewModelScope.launch {
+      _searchState.value = SearchProfileState.Loading
+      try {
+        val results = emptyList<Profile>()
+        _searchState.value = SearchProfileState.Success(results)
+      } catch (e: Exception) {
+        _searchState.value = SearchProfileState.Error(e.message ?: "Load history failed")
+      }
+    }
   }
 
   override fun onCleared() {

--- a/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/eduverse/viewmodel/ProfileViewModel.kt
@@ -192,10 +192,20 @@ open class ProfileViewModel(open val repository: ProfileRepository) : ViewModel(
     searchJob = viewModelScope.launch {
       _searchState.value = SearchProfileState.Loading
       try {
-        val results = emptyList<Profile>()
+        val results = repository.loadSearchHistory(userId)
         _searchState.value = SearchProfileState.Success(results)
       } catch (e: Exception) {
         _searchState.value = SearchProfileState.Error(e.message ?: "Load history failed")
+      }
+    }
+  }
+
+  open fun addProfileToHistory(userId: String, searchedProfileId: String) {
+    viewModelScope.launch {
+      try {
+        repository.addProfileToHistory(userId, searchedProfileId)
+      } catch (e: Exception) {
+        _error.value = "Failed to add profile to history: ${e.message}"
       }
     }
   }

--- a/app/src/test/java/com/github/se/eduverse/repository/ProfileRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/ProfileRepositoryTest.kt
@@ -132,6 +132,10 @@ class ProfileRepositoryImplTest {
             TODO("Not yet implemented")
           }
 
+          override suspend fun addProfileToHistory(userId: String, searchedProfileId: String) {
+            TODO("Not yet implemented")
+          }
+
           override suspend fun createProfile(
               userId: String,
               defaultUsername: String,
@@ -1406,6 +1410,31 @@ class ProfileRepositoryImplTest {
     assertEquals("3", result[2].id)
     assertEquals("4", result[3].id)
     assertEquals("5", result[4].id)
+  }
+
+  @Test
+  fun `loadSearchHistory returns an empty list on error`() = runTest {
+    val result = repository.loadSearchHistory("")
+    assertTrue(result.isEmpty())
+  }
+
+  @Test
+  fun `addProfileToHistory create the correct document`() = runTest {
+    val userId = "testUser"
+
+    whenever(mockCollectionRef.document(userId)).thenReturn(mockDocumentRef)
+    whenever(mockDocumentRef.collection("searchHistory")).thenReturn(mockCollectionRef)
+    whenever(mockCollectionRef.add(any())).then {
+      val map = it.getArgument<HashMap<String, Any>>(0)
+      assertEquals(2, map.size)
+      assertEquals(setOf("timestamp", "id"), map.keys)
+      assertEquals("mathieu", map.get("id"))
+      Tasks.forResult(null)
+    }
+
+    repository.addProfileToHistory(userId, "mathieu")
+
+    org.mockito.kotlin.verify(mockCollectionRef).add(any())
   }
 
   @After

--- a/app/src/test/java/com/github/se/eduverse/repository/ProfileRepositoryTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/repository/ProfileRepositoryTest.kt
@@ -1377,7 +1377,8 @@ class ProfileRepositoryImplTest {
 
     whenever(mockCollectionRef.document("testUser")).thenReturn(mockDocumentRef)
     whenever(mockDocumentRef.collection("searchHistory")).thenReturn(mockCollectionRef)
-    whenever(mockCollectionRef.orderBy("timestamp", Query.Direction.DESCENDING)).thenReturn(mockQuery)
+    whenever(mockCollectionRef.orderBy("timestamp", Query.Direction.DESCENDING))
+        .thenReturn(mockQuery)
     whenever(mockQuery.limit(5)).thenReturn(mockQuery)
     whenever(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
     whenever(mockQuerySnapshot.documents).then {

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/ProfileViewModelTest.kt
@@ -746,6 +746,60 @@ class ProfileViewModelTest {
     assertEquals(errorMessage, (state as FavoriteActionState.Error).message)
   }
 
+  @Test
+  fun `loadSearchHistory loads history successfully`() = runTest {
+    val userId = "testUser"
+    val history = listOf(Profile(id = "1"), Profile(id = "2"))
+
+    `when`(mockRepository.loadSearchHistory(userId)).thenReturn(history)
+
+    profileViewModel.loadSearchHistory(userId)
+    advanceUntilIdle()
+
+    assertEquals(SearchProfileState.Success(history), profileViewModel.searchState.value)
+  }
+
+  @Test
+  fun `loadSearchHistory does nothing on null username`() = runTest {
+    profileViewModel.loadSearchHistory(null)
+    advanceUntilIdle()
+
+    assertEquals(SearchProfileState.Idle, profileViewModel.searchState.value)
+  }
+
+  @Test
+  fun `loadSearchHistory handles error gracefully`() = runTest {
+    val userId = "testUser"
+
+    `when`(mockRepository.loadSearchHistory(userId)).thenThrow(RuntimeException("message"))
+
+    profileViewModel.loadSearchHistory(userId)
+    advanceUntilIdle()
+
+    assertEquals(SearchProfileState.Error("message"), profileViewModel.searchState.value)
+  }
+
+  @Test
+  fun `addProfileToHistory add profile successfully`() = runTest {
+    val userId = "userId"
+    val searchedProfileId = "searchedProfileId"
+
+    profileViewModel.addProfileToHistory(userId, searchedProfileId)
+    advanceUntilIdle()
+
+    verify(mockRepository).addProfileToHistory(userId, searchedProfileId)
+  }
+
+  @Test
+  fun `addProfileToHistory handles error gracefully`() = runTest {
+    `when`(mockRepository.addProfileToHistory(anyString(), anyString())).thenThrow(RuntimeException("message"))
+
+    profileViewModel.addProfileToHistory("", "")
+    advanceUntilIdle()
+
+    assertEquals("Failed to add profile to history: message", profileViewModel.error.value)
+  }
+
   @After
   fun tearDown() {
     Dispatchers.resetMain()

--- a/app/src/test/java/com/github/se/eduverse/viewmodel/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/github/se/eduverse/viewmodel/ProfileViewModelTest.kt
@@ -792,7 +792,8 @@ class ProfileViewModelTest {
 
   @Test
   fun `addProfileToHistory handles error gracefully`() = runTest {
-    `when`(mockRepository.addProfileToHistory(anyString(), anyString())).thenThrow(RuntimeException("message"))
+    `when`(mockRepository.addProfileToHistory(anyString(), anyString()))
+        .thenThrow(RuntimeException("message"))
 
     profileViewModel.addProfileToHistory("", "")
     advanceUntilIdle()


### PR DESCRIPTION
This PR add a history to the search bar. This means that when starting a research and until the user start typing something, he will see the last 5 research he made. If he hadn't made any, the screen still looks like before. There is no way for now to remove a user from history or to see the whole list of all research.