### PR TITLE
Remove buttons with no action

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/camera/NextScreenTest.kt
@@ -99,14 +99,6 @@ class NextScreenTest {
   }
 
   @Test
-  fun testAddDescriptionTextIsDisplayed() {
-    composeTestRule
-        .onNodeWithTag("addDescriptionText")
-        .assertIsDisplayed()
-        .assertTextEquals("Add description...")
-  }
-
-  @Test
   fun testSaveButtonWorks() {
     assertNotNull(mockBitmap)
 

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SettingsScreenTest.kt
@@ -150,28 +150,6 @@ class SettingsScreenTest {
     // Optionally, verify that signOut() was called on FirebaseAuth if needed
   }
 
-  /**
-   * Test to verify that clicking the add account button shows a toast or a not implemented action.
-   * Since testing Toasts directly is challenging, ensure that the corresponding method is called.
-   */
-  @Test
-  fun addAccountButton_showsNotImplementedToast() {
-    // Arrange: Set up the SettingsScreen
-    composeTestRule.setContent {
-      SettingsScreen(navigationActions = fakeNavigationActions, settingsViewModel = fakeViewModel)
-    }
-
-    // Act: Click the "Add Account" button
-    composeTestRule.onNodeWithTag("addAccountButton").performClick()
-
-    // Assert: Verify the Toast message indirectly (since Toast testing is not straightforward)
-
-    composeTestRule
-        .onNodeWithTag("addAccountButton")
-        .assertExists()
-        .assertHasClickAction() // Verifies the button is clickable
-  }
-
   /** Test to verify that the theme dropdown displays the correct current selection. */
   @Test
   fun themeDropdown_displaysCurrentSelection() {

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/videos/OfflineScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/videos/OfflineScreenTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.eduverse.ui.videos.OfflineScreen
 import java.io.File
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/se/eduverse/ui/videos/VideoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/videos/VideoScreenTest.kt
@@ -81,7 +81,7 @@ class VideoScreenTest {
   }
 
   @Test
-  fun testForYouTextAndSearchIconAreDisplayed() {
+  fun testForYouTextIsDisplayed() {
     // Set the content for the test
     composeTestRule.setContent {
       VideoScreen(
@@ -95,10 +95,6 @@ class VideoScreenTest {
     composeTestRule.waitForIdle()
     // Assert that the "For you" text element is displayed
     composeTestRule.onNodeWithTag("ForYouText").assertIsDisplayed()
-
-    composeTestRule.waitForIdle()
-    // Assert that the search icon element is displayed
-    composeTestRule.onNodeWithTag("SearchIcon").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -62,7 +62,6 @@ import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.Route
 import com.github.se.eduverse.ui.navigation.Screen
 import com.github.se.eduverse.ui.notifications.NotificationsScreen
-import com.github.se.eduverse.ui.offline.OfflineScreen
 import com.github.se.eduverse.ui.pdfGenerator.PdfGeneratorScreen
 import com.github.se.eduverse.ui.pomodoro.PomodoroScreen
 import com.github.se.eduverse.ui.profile.FollowListScreen
@@ -77,6 +76,7 @@ import com.github.se.eduverse.ui.timetable.DetailsEventScreen
 import com.github.se.eduverse.ui.timetable.DetailsTasksScreen
 import com.github.se.eduverse.ui.timetable.TimeTableScreen
 import com.github.se.eduverse.ui.todo.TodoListScreen
+import com.github.se.eduverse.ui.videos.OfflineScreen
 import com.github.se.eduverse.ui.videos.VideoScreen
 import com.github.se.eduverse.viewmodel.AiAssistantViewModel
 import com.github.se.eduverse.viewmodel.CommentsViewModel

--- a/app/src/main/java/com/github/se/eduverse/ui/camera/nextScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/camera/nextScreen.kt
@@ -99,8 +99,8 @@ fun NextScreen(
           modifier =
               Modifier.align(Alignment.TopStart)
                   .padding(top = 56.dp, start = 16.dp)
-                  .width(133.dp)
-                  .height(164.dp)
+                  .width(200.dp)
+                  .height(246.dp)
                   .clip(RoundedCornerShape(15.dp))
                   .background(color = Color(0xFFD9D9D9))
                   .testTag("previewImage"))
@@ -143,23 +143,6 @@ fun NextScreen(
                   .background(color = Color(0xFFD9D9D9))
                   .testTag("previewVideo"))
     }
-
-    // Other unchanged components
-    Text(
-        text = "Add description...",
-        color = Color.Gray,
-        fontSize = 24.sp,
-        modifier =
-            Modifier.align(Alignment.TopStart)
-                .padding(start = 16.dp, top = 240.dp)
-                .testTag("addDescriptionText"),
-        style =
-            TextStyle(
-                fontSize = 24.sp,
-                lineHeight = 20.sp,
-                fontWeight = FontWeight.Normal,
-                letterSpacing = 0.24.sp,
-            ))
 
     Column(
         modifier = Modifier.align(Alignment.CenterStart).padding(start = 16.dp, top = 320.dp),

--- a/app/src/main/java/com/github/se/eduverse/ui/setting/Setting.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/setting/Setting.kt
@@ -178,20 +178,6 @@ fun SettingsScreen(
                 elevation = CardDefaults.cardElevation(4.dp)) {
                   Column(modifier = Modifier.padding(16.dp)) {
                     Button(
-                        onClick = { showNotImplementedToast(context) },
-                        modifier = Modifier.fillMaxWidth().testTag("addAccountButton"),
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.secondary)) {
-                          Icon(
-                              imageVector = Icons.Default.PersonAdd,
-                              contentDescription = "Add Account",
-                              modifier = Modifier.padding(end = 8.dp),
-                              tint = Color.White)
-                          Text(text = "Add Account", color = Color.White)
-                        }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
                         onClick = { logout(navigationActions) },
                         modifier = Modifier.fillMaxWidth().testTag("logoutButton"),
                         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD4DEE8))) {

--- a/app/src/main/java/com/github/se/eduverse/ui/videos/Videos.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/videos/Videos.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -190,16 +189,6 @@ fun VideoScreen(
                             Modifier.align(Alignment.TopCenter)
                                 .padding(top = 16.dp)
                                 .testTag("ForYouText"))
-
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search",
-                        tint = Color.White,
-                        modifier =
-                            Modifier.align(Alignment.TopEnd)
-                                .padding(top = 16.dp, end = 16.dp)
-                                .size(32.dp)
-                                .testTag("SearchIcon"))
                   }
             },
             bottomBar = {

--- a/app/src/main/java/com/github/se/eduverse/ui/videos/offlineVideos.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/videos/offlineVideos.kt
@@ -1,4 +1,4 @@
-package com.github.se.eduverse.ui.offline
+package com.github.se.eduverse.ui.videos
 
 import android.content.Context
 import android.net.Uri


### PR DESCRIPTION
This PR removes buttons that didn't do anything in the app :

1. Add account in the setting screen
2. Search in the video screen
3. Add description in camera's nextScreen. To avoid leaving a void in the screen, I increased the size of the image view by +50%.