### PR TITLE
 Add Comment Functionality in the Profile Screen and the User Profile Screen. DO NOT MERGE

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/E2E/SocialInteractionE2ETest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/E2E/SocialInteractionE2ETest.kt
@@ -23,6 +23,7 @@ import com.github.se.eduverse.ui.search.TAG_PROFILE_ITEM
 import com.github.se.eduverse.ui.search.TAG_PROFILE_LIST
 import com.github.se.eduverse.ui.search.TAG_SEARCH_FIELD
 import com.github.se.eduverse.ui.search.UserProfileScreen
+import com.github.se.eduverse.viewmodel.CommentsViewModel
 import com.github.se.eduverse.viewmodel.ProfileUiState
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.SearchProfileState
@@ -36,6 +37,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class SocialInteractionE2ETest {
 
@@ -160,6 +162,7 @@ fun TestNavigation2(
             navigationActions = navigationActions,
             viewModel = viewModel,
             userId = "test_user_id",
+            commentsViewModel = CommentsViewModel(mock(), mock()),
             currentUserId = "current_user_id")
     else -> DashboardScreen(viewModel = dashboardViewModel, navigationActions = navigationActions)
   }

--- a/app/src/main/java/com/github/se/eduverse/MainActivity.kt
+++ b/app/src/main/java/com/github/se/eduverse/MainActivity.kt
@@ -313,7 +313,10 @@ fun EduverseApp(
                   ?: return@composable // Handle missing userId
 
           UserProfileScreen(
-              navigationActions = navigationActions, viewModel = profileViewModel, userId = userId)
+              navigationActions = navigationActions,
+              viewModel = profileViewModel,
+              commentsViewModel = CommentsViewModel,
+              userId = userId)
         }
 
     navigation(
@@ -393,11 +396,15 @@ fun EduverseApp(
         startDestination = Screen.PROFILE,
         route = Route.PROFILE,
     ) {
-      composable(Screen.PROFILE) { ProfileScreen(navigationActions, profileViewModel) }
+      composable(Screen.PROFILE) {
+        ProfileScreen(navigationActions, profileViewModel, CommentsViewModel)
+      }
 
       composable(Screen.SETTING) { SettingsScreen(navigationActions, settingsViewModel) }
 
-      composable(Screen.EDIT_PROFILE) { ProfileScreen(navigationActions, profileViewModel) }
+      composable(Screen.EDIT_PROFILE) {
+        ProfileScreen(navigationActions, profileViewModel, CommentsViewModel)
+      }
 
       composable(Screen.GALLERY) {
         val ownerId = FirebaseAuth.getInstance().currentUser?.uid ?: ""

--- a/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/profile/ProfileScreen.kt
@@ -2,6 +2,7 @@ package com.github.se.eduverse.ui.profile
 
 import android.annotation.SuppressLint
 import android.net.Uri
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -10,8 +11,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Article
 import androidx.compose.material.icons.filled.BookmarkAdd
@@ -19,8 +24,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -34,18 +39,19 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.github.se.eduverse.R
 import com.github.se.eduverse.model.MediaType
 import com.github.se.eduverse.model.Publication
+import com.github.se.eduverse.ui.gallery.PublicationItem
 import com.github.se.eduverse.ui.navigation.BottomNavigationMenu
 import com.github.se.eduverse.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.Route
 import com.github.se.eduverse.ui.navigation.Screen
-import com.github.se.eduverse.viewmodel.DeletePublicationState
+import com.github.se.eduverse.viewmodel.CommentsUiState
+import com.github.se.eduverse.viewmodel.CommentsViewModel
 import com.github.se.eduverse.viewmodel.ProfileUiState
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.github.se.eduverse.viewmodel.UsernameUpdateState
@@ -53,12 +59,13 @@ import com.google.firebase.auth.FirebaseAuth
 
 var auth = FirebaseAuth.getInstance()
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @SuppressLint("SuspiciousIndentation")
 @Composable
 fun ProfileScreen(
     navigationActions: NavigationActions,
     viewModel: ProfileViewModel,
+    commentsViewModel: CommentsViewModel,
     userId: String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
 ) {
   var showUsernameDialog by remember { mutableStateOf(false) }
@@ -72,12 +79,37 @@ fun ProfileScreen(
         uri?.let { viewModel.updateProfileImage(userId, it) }
       }
 
+  var isCommentsVisible by remember { mutableStateOf(false) }
+  var selectedPublication by remember { mutableStateOf<Publication?>(null) }
+  var selectedPublicationId by remember { mutableStateOf<String?>(null) }
+
+  val sheetState =
+      rememberModalBottomSheetState(
+          initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+
+  // Handle opening and closing of the sheet
+  LaunchedEffect(isCommentsVisible) {
+    if (isCommentsVisible && selectedPublicationId != null) {
+      sheetState.show()
+      commentsViewModel.loadComments(selectedPublicationId!!)
+    } else {
+      sheetState.hide()
+    }
+  }
+
+  // Observe changes in the sheet's state to update isCommentsVisible
+  LaunchedEffect(sheetState.currentValue) {
+    if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
+      isCommentsVisible = false
+      selectedPublicationId = null
+    }
+  }
+
   LaunchedEffect(userId) {
     if (auth.currentUser == null) {
       navigationActions.navigateTo(Screen.AUTH)
       return@LaunchedEffect
     }
-
     viewModel.loadProfile(userId)
     viewModel.loadLikedPublications(userId)
   }
@@ -97,493 +129,356 @@ fun ProfileScreen(
         })
   }
 
-  Scaffold(
-      topBar = {
-        TopAppBar(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .background(
-                        Brush.horizontalGradient(
-                            colors =
-                                listOf(
-                                    MaterialTheme.colorScheme.secondary,
-                                    MaterialTheme.colorScheme.primary)))
-                    .testTag("topNavigationBar"),
-            title = {
-              when (uiState) {
-                is ProfileUiState.Success -> {
-                  Row(
-                      verticalAlignment = Alignment.CenterVertically,
-                      modifier = Modifier.clickable { showUsernameDialog = true }) {
-                        Text(
-                            text = (uiState as ProfileUiState.Success).profile.username,
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.testTag("profile_username"))
-                        IconButton(
-                            onClick = { showUsernameDialog = true },
-                            modifier = Modifier.testTag("edit_username_button")) {
-                              Icon(
-                                  imageVector = Icons.Default.Edit,
-                                  contentDescription = "Edit username",
-                                  tint = MaterialTheme.colorScheme.onPrimary)
+  ModalBottomSheetLayout(
+      sheetContent = {
+        if (isCommentsVisible && selectedPublicationId != null) {
+          CommentsMenuContent(
+              publicationId = selectedPublicationId!!,
+              commentsViewModel = commentsViewModel,
+              currentUserId = userId,
+              onDismiss = {
+                isCommentsVisible = false
+                selectedPublicationId = null
+              })
+        } else {
+          Spacer(modifier = Modifier.height(1.dp))
+        }
+      },
+      sheetState = sheetState,
+      scrimColor = Color.Black.copy(alpha = 0.32f)) {
+        Scaffold(
+            topBar = {
+              TopAppBar(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .background(
+                              Brush.horizontalGradient(
+                                  colors =
+                                      listOf(
+                                          MaterialTheme.colorScheme.secondary,
+                                          MaterialTheme.colorScheme.primary)))
+                          .testTag("topNavigationBar"),
+                  title = {
+                    when (uiState) {
+                      is ProfileUiState.Success -> {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.clickable { showUsernameDialog = true }) {
+                              Text(
+                                  text = (uiState as ProfileUiState.Success).profile.username,
+                                  style = MaterialTheme.typography.titleLarge,
+                                  color = MaterialTheme.colorScheme.onPrimary,
+                                  modifier = Modifier.testTag("profile_username"))
+                              IconButton(
+                                  onClick = { showUsernameDialog = true },
+                                  modifier = Modifier.testTag("edit_username_button")) {
+                                    Icon(
+                                        imageVector =
+                                            androidx.compose.material.icons.Icons.Default.Edit,
+                                        contentDescription = "Edit username",
+                                        tint = MaterialTheme.colorScheme.onPrimary)
+                                  }
                             }
                       }
-                }
-                else -> {
-                  Text(
-                      "Profile",
-                      style = MaterialTheme.typography.titleLarge,
-                      color = MaterialTheme.colorScheme.onPrimary,
-                      modifier = Modifier.testTag("profile_title_default"))
-                }
-              }
+                      else -> {
+                        Text(
+                            "Profile",
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.testTag("profile_title_default"))
+                      }
+                    }
+                  },
+                  colors =
+                      TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Transparent),
+                  actions = {
+                    IconButton(
+                        onClick = { navigationActions.navigateTo(Screen.SETTING) },
+                        modifier = Modifier.testTag("settings_button")) {
+                          Icon(
+                              imageVector = androidx.compose.material.icons.Icons.Default.Settings,
+                              contentDescription = "Settings",
+                              tint = MaterialTheme.colorScheme.onPrimary)
+                        }
+                  })
             },
-            colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Transparent),
-            actions = {
-              IconButton(
-                  onClick = { navigationActions.navigateTo(Screen.SETTING) },
-                  modifier = Modifier.testTag("settings_button")) {
-                    Icon(
-                        imageVector = Icons.Default.Settings,
-                        contentDescription = "Settings",
-                        tint = MaterialTheme.colorScheme.onPrimary)
-                  }
-            })
-      },
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = Route.PROFILE)
-      }) { paddingValues ->
-        Column(
-            modifier =
-                Modifier.testTag("profile_content_container")
-                    .fillMaxSize()
-                    .padding(paddingValues)) {
-              Spacer(modifier = Modifier.height(12.dp))
+            bottomBar = {
+              BottomNavigationMenu(
+                  onTabSelect = { route -> navigationActions.navigateTo(route) },
+                  tabList = LIST_TOP_LEVEL_DESTINATION,
+                  selectedItem = Route.PROFILE)
+            }) { paddingValues ->
+              Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                Column(modifier = Modifier.testTag("profile_content_container").fillMaxSize()) {
+                  Spacer(modifier = Modifier.height(12.dp))
 
-              Box(
-                  modifier =
-                      Modifier.testTag("profile_image_container")
-                          .fillMaxWidth()
-                          .padding(top = 16.dp),
-                  contentAlignment = Alignment.Center) {
-                    ProfileImage(
-                        imageUrl =
-                            if (uiState is ProfileUiState.Success)
-                                (uiState as ProfileUiState.Success).profile.profileImageUrl
-                            else "",
-                        onImageClick = { launcher.launch("image/*") },
-                        modifier = Modifier.testTag("profile_image"))
-                  }
-
-              when (uiState) {
-                is ProfileUiState.Success -> {
-                  val profile = (uiState as ProfileUiState.Success).profile
-                  Row(
-                      modifier = Modifier.testTag("stats_row").fillMaxWidth().padding(16.dp),
-                      horizontalArrangement = Arrangement.SpaceEvenly) {
-                        StatItem(
-                            "Followers",
-                            profile.followers,
-                            onClick = { navigationActions.navigateToFollowersList(profile.id) },
-                            Modifier.testTag("followers_stat"))
-                        StatItem(
-                            "Following",
-                            profile.following,
-                            onClick = { navigationActions.navigateToFollowingList(profile.id) },
-                            Modifier.testTag("following_stat"))
-                      }
-                }
-                else -> {}
-              }
-
-              TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
-                Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    text = {
-                      Text(
-                          "Publications",
-                          style = MaterialTheme.typography.labelLarge,
-                          color =
-                              if (selectedTab == 0) MaterialTheme.colorScheme.primary
-                              else MaterialTheme.colorScheme.onSurface)
-                    },
-                    icon = {
-                      Icon(
-                          Icons.Default.Article,
-                          contentDescription = null,
-                          tint =
-                              if (selectedTab == 0) MaterialTheme.colorScheme.primary
-                              else MaterialTheme.colorScheme.onSurface)
-                    },
-                    modifier = Modifier.testTag("publications_tab"))
-                Tab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
-                    text = {
-                      Text(
-                          "Favorites",
-                          style = MaterialTheme.typography.labelLarge,
-                          color =
-                              if (selectedTab == 1) MaterialTheme.colorScheme.primary
-                              else MaterialTheme.colorScheme.onSurface)
-                    },
-                    icon = {
-                      Icon(
-                          Icons.Default.Favorite,
-                          contentDescription = null,
-                          tint =
-                              if (selectedTab == 1) MaterialTheme.colorScheme.primary
-                              else MaterialTheme.colorScheme.onSurface)
-                    },
-                    modifier = Modifier.testTag("favorites_tab"))
-              }
-
-              when (uiState) {
-                is ProfileUiState.Loading -> {
                   Box(
-                      modifier = Modifier.testTag("loading_container").fillMaxSize(),
+                      modifier =
+                          Modifier.testTag("profile_image_container")
+                              .fillMaxWidth()
+                              .padding(top = 16.dp),
                       contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.testTag("loading_indicator"))
-                      }
-                }
-                is ProfileUiState.Error ->
-                    ErrorMessage(
-                        message = (uiState as ProfileUiState.Error).message,
-                        modifier = Modifier.testTag("error_container"))
-                is ProfileUiState.Success -> {
-                  val profile = (uiState as ProfileUiState.Success).profile
-                  val publications =
-                      if (selectedTab == 0) {
-                        profile.publications
-                      } else {
-                        likedPublications
+                        ProfileImage(
+                            imageUrl =
+                                if (uiState is ProfileUiState.Success)
+                                    (uiState as ProfileUiState.Success).profile.profileImageUrl
+                                else "",
+                            onImageClick = { launcher.launch("image/*") },
+                            modifier = Modifier.testTag("profile_image"))
                       }
 
-                  PublicationsGrid(
-                      publications = publications,
-                      currentUserId = userId,
+                  when (uiState) {
+                    is ProfileUiState.Success -> {
+                      val profile = (uiState as ProfileUiState.Success).profile
+                      Row(
+                          modifier = Modifier.testTag("stats_row").fillMaxWidth().padding(16.dp),
+                          horizontalArrangement = Arrangement.SpaceEvenly) {
+                            StatItem(
+                                "Followers",
+                                profile.followers,
+                                onClick = { navigationActions.navigateToFollowersList(profile.id) },
+                                Modifier.testTag("followers_stat"))
+                            StatItem(
+                                "Following",
+                                profile.following,
+                                onClick = { navigationActions.navigateToFollowingList(profile.id) },
+                                Modifier.testTag("following_stat"))
+                          }
+                    }
+                    else -> {}
+                  }
+
+                  TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = {
+                          Text(
+                              "Publications",
+                              style = MaterialTheme.typography.labelLarge,
+                              color =
+                                  if (selectedTab == 0) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                        },
+                        icon = {
+                          Icon(
+                              Icons.Default.Article,
+                              contentDescription = null,
+                              tint =
+                                  if (selectedTab == 0) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                        },
+                        modifier = Modifier.testTag("publications_tab"))
+                    Tab(
+                        selected = selectedTab == 1,
+                        onClick = { selectedTab = 1 },
+                        text = {
+                          Text(
+                              "Favorites",
+                              style = MaterialTheme.typography.labelLarge,
+                              color =
+                                  if (selectedTab == 1) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                        },
+                        icon = {
+                          Icon(
+                              Icons.Default.Favorite,
+                              contentDescription = null,
+                              tint =
+                                  if (selectedTab == 1) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                        },
+                        modifier = Modifier.testTag("favorites_tab"))
+                  }
+
+                  when (uiState) {
+                    is ProfileUiState.Loading -> {
+                      Box(
+                          modifier = Modifier.testTag("loading_container").fillMaxSize(),
+                          contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.testTag("loading_indicator"))
+                          }
+                    }
+                    is ProfileUiState.Error ->
+                        ErrorMessage(
+                            message = (uiState as ProfileUiState.Error).message,
+                            modifier = Modifier.testTag("error_container"))
+                    is ProfileUiState.Success -> {
+                      val profile = (uiState as ProfileUiState.Success).profile
+                      val publications =
+                          if (selectedTab == 0) {
+                            profile.publications
+                          } else {
+                            likedPublications
+                          }
+
+                      LazyVerticalGrid(
+                          columns = GridCells.Fixed(3),
+                          modifier = Modifier.testTag("publications_grid").fillMaxSize(),
+                          contentPadding = PaddingValues(1.dp),
+                          horizontalArrangement = Arrangement.spacedBy(1.dp),
+                          verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                            items(publications) { publication ->
+                              PublicationItem(
+                                  publication.mediaType,
+                                  publication.thumbnailUrl,
+                                  onClick = { selectedPublication = publication },
+                                  modifier = Modifier.testTag("publication_item_${publication.id}"))
+                            }
+                          }
+                    }
+                  }
+                }
+
+                selectedPublication?.let { publication ->
+                  PublicationDetailView(
+                      publication = publication,
                       profileViewModel = viewModel,
-                      onPublicationClick = {},
-                      modifier = Modifier.testTag("publications_grid"))
+                      currentUserId = userId,
+                      onDismiss = { selectedPublication = null },
+                      onShowComments = { pubId ->
+                        selectedPublicationId = pubId
+                        isCommentsVisible = true
+                      })
                 }
               }
             }
-      }
-}
-
-@Composable
-private fun StatItem(
-    label: String,
-    count: Int,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-  Column(
-      modifier = modifier.clickable(onClick = onClick).testTag("stat_${label.lowercase()}"),
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = count.toString(),
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.testTag("stat_count_$label"))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.testTag("stat_label_$label"))
-      }
-}
-
-@Composable
-fun PublicationItem(publication: Publication, onClick: () -> Unit, modifier: Modifier = Modifier) {
-  Card(
-      modifier = modifier.aspectRatio(1f).clickable(onClick = onClick),
-      shape = RoundedCornerShape(8.dp)) {
-        Box(modifier = Modifier.testTag("publication_content_${publication.id}").fillMaxSize()) {
-          AsyncImage(
-              model =
-                  ImageRequest.Builder(LocalContext.current)
-                      .data(publication.thumbnailUrl)
-                      .crossfade(true)
-                      .listener(
-                          onError = { _, _ ->
-                            println("Failed to load thumbnail for ${publication.id}")
-                          },
-                          onSuccess = { _, _ ->
-                            println("Successfully loaded thumbnail for ${publication.id}")
-                          })
-                      .build(),
-              contentDescription = "Publication thumbnail",
-              modifier = Modifier.testTag("publication_thumbnail_${publication.id}").fillMaxSize(),
-              contentScale = ContentScale.Crop,
-              error = painterResource(R.drawable.eduverse_logo_alone),
-              fallback = painterResource(R.drawable.eduverse_logo_alone),
-          )
-
-          // Video indicator overlay
-          if (publication.mediaType == MediaType.VIDEO) {
-            Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)))
-
-            Icon(
-                imageVector = Icons.Default.PlayCircle,
-                contentDescription = "Video",
-                modifier =
-                    Modifier.size(48.dp)
-                        .align(Alignment.Center)
-                        .testTag("video_play_icon_${publication.id}"), // Add this testTag
-                tint = Color.White)
-          }
-        }
       }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PublicationDetailDialog(
+fun PublicationDetailView(
     publication: Publication,
     profileViewModel: ProfileViewModel,
     currentUserId: String,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onShowComments: (String) -> Unit
 ) {
   val isLiked = remember { mutableStateOf(publication.likedBy.contains(currentUserId)) }
   val likeCount = remember { mutableStateOf(publication.likes) }
-  var showDeleteDialog by remember { mutableStateOf(false) }
-  val deleteState by profileViewModel.deletePublicationState.collectAsState()
-  val favoriteState by profileViewModel.favoriteActionState.collectAsState()
-
-  // Track if publication is favorited
   var isFavorited by remember { mutableStateOf(false) }
 
-  // Check if publication is favorited on initial load
   LaunchedEffect(publication.id) {
     isFavorited = profileViewModel.repository.isPublicationFavorited(currentUserId, publication.id)
   }
 
-  var errorMessage by remember { mutableStateOf<String?>(null) }
-
-  // Handle delete state changes
-  LaunchedEffect(deleteState) {
-    when (deleteState) {
-      is DeletePublicationState.Success -> {
-        errorMessage = null
-        onDismiss()
-        profileViewModel.resetDeleteState()
-      }
-      is DeletePublicationState.Error -> {
-        errorMessage = (deleteState as DeletePublicationState.Error).message
-        profileViewModel.resetDeleteState()
-      }
-      else -> {
-        errorMessage = null
-      }
-    }
-  }
-
-  // Confirmation dialog for delete action
-  if (showDeleteDialog) {
-    AlertDialog(
-        onDismissRequest = { showDeleteDialog = false },
-        title = { Text("Delete Publication") },
-        text = {
-          Text("Are you sure you want to delete this publication? This action cannot be undone.")
-        },
-        confirmButton = {
-          Button(
-              onClick = {
-                profileViewModel.deletePublication(publication.id, currentUserId)
-                showDeleteDialog = false
+  Box(
+      modifier =
+          Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.7f)).clickable {
+            onDismiss()
+          }) {
+        Column(modifier = Modifier.fillMaxSize().padding(32.dp).background(Color.Black)) {
+          SmallTopAppBar(
+              title = {
+                Text(
+                    publication.title,
+                    color = Color.White,
+                    modifier = Modifier.testTag("publication_title"))
+              },
+              navigationIcon = {
+                IconButton(onClick = onDismiss, modifier = Modifier.testTag("close_button")) {
+                  Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
               },
               colors =
-                  ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)) {
-                Text("Delete")
-              }
-        },
-        dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") } })
-  }
+                  TopAppBarDefaults.smallTopAppBarColors(
+                      containerColor = Color.Black, titleContentColor = Color.White))
 
-  Dialog(
-      onDismissRequest = onDismiss,
-      properties =
-          DialogProperties(
-              usePlatformDefaultWidth = false,
-              dismissOnBackPress = true,
-              dismissOnClickOutside = false)) {
-        Box(modifier = Modifier.fillMaxSize().testTag("publication_detail_dialog")) {
-          Column(modifier = Modifier.fillMaxSize()) {
-            Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
-              Column(modifier = Modifier.fillMaxSize()) {
-                SmallTopAppBar(
-                    title = {
-                      Text(
-                          publication.title,
-                          color = Color.White,
-                          modifier = Modifier.testTag("publication_title"))
-                    },
-                    navigationIcon = {
-                      IconButton(onClick = onDismiss, modifier = Modifier.testTag("close_button")) {
-                        Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
-                      }
-                    },
-                    actions = {
-                      if (publication.userId == currentUserId) {
+          Box(
+              modifier = Modifier.weight(1f).fillMaxWidth().testTag("media_container"),
+              contentAlignment = Alignment.Center) {
+                when (publication.mediaType) {
+                  MediaType.VIDEO -> {
+                    ExoVideoPlayer(
+                        videoUrl = publication.mediaUrl,
+                        modifier = Modifier.fillMaxWidth().testTag("video_player"))
+                  }
+                  MediaType.PHOTO -> {
+                    AsyncImage(
+                        model =
+                            ImageRequest.Builder(LocalContext.current)
+                                .data(publication.mediaUrl)
+                                .crossfade(true)
+                                .build(),
+                        contentDescription = "Publication media",
+                        modifier = Modifier.fillMaxSize().testTag("detail_photo_view"),
+                        contentScale = ContentScale.Fit)
+                  }
+                }
+
+                // Action Buttons Column (Like, Comment, Favorite)
+                Column(
+                    modifier =
+                        Modifier.align(Alignment.CenterEnd)
+                            .padding(16.dp)
+                            .testTag("action_buttons"),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                      // Like Button
+                      Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         IconButton(
-                            onClick = { showDeleteDialog = true },
-                            modifier = Modifier.testTag("delete_button")) {
+                            onClick = {
+                              if (isLiked.value) {
+                                profileViewModel.removeLike(currentUserId, publication.id)
+                                isLiked.value = false
+                                likeCount.value -= 1
+                              } else {
+                                profileViewModel.likeAndAddToFavorites(
+                                    currentUserId, publication.id)
+                                isLiked.value = true
+                                likeCount.value += 1
+                              }
+                            },
+                            modifier = Modifier.testTag("like_button")) {
                               Icon(
-                                  imageVector = Icons.Default.Delete,
-                                  contentDescription = "Delete publication",
-                                  tint = Color.White)
+                                  imageVector = Icons.Default.Favorite,
+                                  contentDescription = "Like",
+                                  tint = if (isLiked.value) Color.Red else Color.White,
+                                  modifier = Modifier.size(48.dp))
                             }
-                      }
-                    },
-                    colors =
-                        TopAppBarDefaults.smallTopAppBarColors(
-                            containerColor = Color.Black, titleContentColor = Color.White))
-
-                Box(
-                    modifier = Modifier.weight(1f).fillMaxWidth().testTag("media_container"),
-                    contentAlignment = Alignment.Center) {
-                      when (publication.mediaType) {
-                        MediaType.VIDEO -> {
-                          ExoVideoPlayer(
-                              videoUrl = publication.mediaUrl,
-                              modifier = Modifier.fillMaxWidth().testTag("video_player"))
-                        }
-                        MediaType.PHOTO -> {
-                          AsyncImage(
-                              model =
-                                  ImageRequest.Builder(LocalContext.current)
-                                      .data(publication.mediaUrl)
-                                      .crossfade(true)
-                                      .build(),
-                              contentDescription = "Publication media",
-                              modifier = Modifier.fillMaxSize().testTag("detail_photo_view"),
-                              contentScale = ContentScale.Fit)
-                        }
+                        Text(
+                            text = likeCount.value.toString(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White,
+                            modifier = Modifier.testTag("like_count_${publication.id}"))
                       }
 
-                      // Action Buttons Column
-                      Column(
-                          modifier =
-                              Modifier.align(Alignment.CenterEnd)
-                                  .padding(16.dp)
-                                  .testTag("action_buttons"),
-                          horizontalAlignment = Alignment.CenterHorizontally,
-                          verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                            // Like Button
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                              IconButton(
-                                  onClick = {
-                                    if (isLiked.value) {
-                                      profileViewModel.removeLike(currentUserId, publication.id)
-                                      isLiked.value = false
-                                      likeCount.value -= 1
-                                    } else {
-                                      profileViewModel.likeAndAddToFavorites(
-                                          currentUserId, publication.id)
-                                      isLiked.value = true
-                                      likeCount.value += 1
-                                    }
-                                  },
-                                  modifier = Modifier.testTag("like_button")) {
-                                    Icon(
-                                        imageVector = Icons.Default.Favorite,
-                                        contentDescription = "Like",
-                                        tint = if (isLiked.value) Color.Red else Color.White,
-                                        modifier =
-                                            Modifier.size(48.dp)
-                                                .testTag(
-                                                    if (isLiked.value) "liked_icon"
-                                                    else "unliked_icon"))
-                                  }
-                              Text(
-                                  text = likeCount.value.toString(),
-                                  style = MaterialTheme.typography.bodyMedium,
-                                  color = Color.White,
-                                  modifier = Modifier.testTag("like_count_${publication.id}"))
-                            }
+                      // Comment Button
+                      IconButton(
+                          onClick = {
+                            onShowComments(publication.id)
+                            Log.d(
+                                "COMMENT",
+                                "Comment button clicked for publication: ${publication.id}")
+                          },
+                          modifier = Modifier.testTag("comment_button")) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.comment),
+                                contentDescription = "Comment",
+                                tint = Color.White,
+                                modifier = Modifier.size(48.dp))
+                          }
 
-                            // Favorite Button
-                            IconButton(
-                                onClick = {
-                                  profileViewModel.toggleFavorite(currentUserId, publication.id)
-                                  isFavorited = !isFavorited
-                                },
-                                modifier = Modifier.testTag("favorite_button")) {
-                                  Icon(
-                                      imageVector = Icons.Default.BookmarkAdd,
-                                      contentDescription = "Favorite",
-                                      tint = if (isFavorited) Color.Yellow else Color.White,
-                                      modifier =
-                                          Modifier.size(48.dp)
-                                              .testTag(
-                                                  if (isFavorited) "favorited_icon"
-                                                  else "unfavorited_icon"))
-                                }
+                      // Favorite Button
+                      IconButton(
+                          onClick = {
+                            profileViewModel.toggleFavorite(currentUserId, publication.id)
+                            isFavorited = !isFavorited
+                          },
+                          modifier = Modifier.testTag("favorite_button")) {
+                            Icon(
+                                imageVector = Icons.Default.BookmarkAdd,
+                                contentDescription = "Favorite",
+                                tint = if (isFavorited) Color.Yellow else Color.White,
+                                modifier = Modifier.size(48.dp))
                           }
                     }
               }
-            }
-          }
         }
       }
-}
-
-@Composable
-private fun PublicationsGrid(
-    publications: List<Publication>,
-    currentUserId: String,
-    profileViewModel: ProfileViewModel,
-    onPublicationClick: (Publication) -> Unit,
-    modifier: Modifier = Modifier
-) {
-  var selectedPublication by remember { mutableStateOf<Publication?>(null) }
-
-  if (publications.isEmpty()) {
-    Box(
-        modifier = Modifier.testTag("empty_publications_container").fillMaxSize(),
-        contentAlignment = Alignment.Center) {
-          Text(
-              text = "No publications yet",
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-              modifier = Modifier.testTag("empty_publications_text"))
-        }
-  } else {
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(1.dp),
-        horizontalArrangement = Arrangement.spacedBy(1.dp),
-        verticalArrangement = Arrangement.spacedBy(1.dp)) {
-          items(publications) { publication ->
-            PublicationItem(
-                publication = publication,
-                onClick = { selectedPublication = publication },
-                modifier = Modifier.testTag("publication_item_${publication.id}"))
-          }
-        }
-
-    // Show detail dialog when a publication is selected
-    selectedPublication?.let { publication ->
-      PublicationDetailDialog(
-          publication = publication,
-          profileViewModel = profileViewModel,
-          currentUserId = currentUserId,
-          onDismiss = { selectedPublication = null })
-    }
-  }
-}
-
-@Composable
-private fun VideoPlayer(videoUrl: String, modifier: Modifier = Modifier) {
-  ExoVideoPlayer(videoUrl = videoUrl, modifier = modifier)
 }
 
 @Composable
@@ -703,4 +598,221 @@ private fun UsernameEditDialog(
               }
         }
   }
+}
+
+@Composable
+fun CommentSection(
+    publicationId: String,
+    commentsViewModel: CommentsViewModel,
+    currentUserId: String
+) {
+  val commentsState by commentsViewModel.commentsState.collectAsState()
+  val context = LocalContext.current
+  var newCommentText by remember { mutableStateOf("") }
+
+  // Load comments when this UI is shown or when publicationId changes
+  LaunchedEffect(publicationId) { commentsViewModel.loadComments(publicationId) }
+
+  Column(
+      modifier =
+          Modifier.fillMaxHeight(0.75f).fillMaxWidth().padding(16.dp).testTag("CommentsSection")) {
+        Text(
+            "Comments",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(bottom = 8.dp))
+
+        when (commentsState) {
+          is CommentsUiState.Loading -> {
+            Box(
+                modifier = Modifier.fillMaxSize().testTag("CommentsLoadingIndicator"),
+                contentAlignment = Alignment.Center) {
+                  CircularProgressIndicator()
+                }
+          }
+          is CommentsUiState.Success -> {
+            val comments = (commentsState as CommentsUiState.Success).comments
+            androidx.compose.foundation.lazy.LazyColumn(
+                modifier = Modifier.weight(1f).testTag("CommentsList")) {
+                  items(comments) { comment ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                            Modifier.padding(vertical = 4.dp)
+                                .fillMaxWidth()
+                                .testTag("CommentItem_${comment.id}")) {
+                          // Profile image
+                          if (!comment.profile?.profileImageUrl.isNullOrBlank()) {
+                            coil.compose.SubcomposeAsyncImage(
+                                model = comment.profile?.profileImageUrl,
+                                contentDescription = "Profile Image",
+                                modifier =
+                                    Modifier.size(32.dp)
+                                        .clip(CircleShape)
+                                        .testTag("ProfileImage_${comment.id}"))
+                          } else {
+                            Box(
+                                modifier =
+                                    Modifier.size(32.dp)
+                                        .clip(CircleShape)
+                                        .background(Color.Gray)
+                                        .testTag("ProfileImagePlaceholder_${comment.id}"))
+                          }
+
+                          Spacer(modifier = Modifier.width(8.dp))
+
+                          Column(
+                              modifier =
+                                  Modifier.weight(1f).testTag("CommentContent_${comment.id}")) {
+                                Text(
+                                    text = comment.profile?.username ?: "Unknown",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.testTag("CommentUsername_${comment.id}"))
+                                Text(
+                                    text = comment.text,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    modifier = Modifier.testTag("CommentText_${comment.id}"))
+                              }
+
+                          Column(
+                              horizontalAlignment = Alignment.CenterHorizontally,
+                              modifier =
+                                  Modifier.padding(end = 8.dp)
+                                      .testTag("LikeCommentSection_${comment.id}")) {
+                                IconButton(
+                                    onClick = {
+                                      commentsViewModel.likeComment(
+                                          publicationId, comment.id, currentUserId)
+                                    },
+                                    modifier =
+                                        Modifier.size(24.dp)
+                                            .testTag("LikeCommentButton_${comment.id}")) {
+                                      Icon(
+                                          imageVector = Icons.Default.Favorite,
+                                          contentDescription = "Like",
+                                          tint =
+                                              if (comment.likedBy.contains(currentUserId)) Color.Red
+                                              else Color.Gray,
+                                          modifier =
+                                              Modifier.testTag("LikeCommentIcon_${comment.id}"))
+                                    }
+                                Text(
+                                    text = comment.likes.toString(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    modifier = Modifier.testTag("CommentLikes_${comment.id}"))
+                              }
+
+                          if (comment.ownerId == currentUserId) {
+                            IconButton(
+                                onClick = {
+                                  commentsViewModel.deleteComment(publicationId, comment.id)
+                                },
+                                modifier =
+                                    Modifier.size(24.dp)
+                                        .testTag("DeleteCommentButton_${comment.id}")) {
+                                  Icon(
+                                      imageVector =
+                                          androidx.compose.material.icons.Icons.Default.Delete,
+                                      contentDescription = "Delete",
+                                      tint = Color.Gray,
+                                      modifier =
+                                          Modifier.testTag("DeleteCommentIcon_${comment.id}"))
+                                }
+                          }
+                        }
+                  }
+                }
+          }
+          is CommentsUiState.Error -> {
+            val errorMessage = (commentsState as CommentsUiState.Error).message
+            Box(
+                modifier = Modifier.fillMaxSize().testTag("CommentsErrorIndicator"),
+                contentAlignment = Alignment.Center) {
+                  Text(text = errorMessage, color = Color.Red)
+                }
+          }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Input field and Post button
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.testTag("NewCommentSection")) {
+              TextField(
+                  value = newCommentText,
+                  onValueChange = { newCommentText = it },
+                  modifier = Modifier.weight(1f).testTag("NewCommentTextField"),
+                  placeholder = { Text("Write a comment...") })
+              Spacer(modifier = Modifier.width(8.dp))
+              Button(
+                  onClick = {
+                    if (newCommentText.isNotBlank()) {
+                      val ownerId = currentUserId.ifBlank { "anonymous" }
+                      commentsViewModel.addComment(publicationId, ownerId, newCommentText)
+                      newCommentText = "" // Clear the input field
+                    } else {
+                      android.widget.Toast.makeText(
+                              context, "Comment cannot be empty", android.widget.Toast.LENGTH_SHORT)
+                          .show()
+                    }
+                  },
+                  modifier = Modifier.testTag("PostCommentButton")) {
+                    Text("Post")
+                  }
+            }
+      }
+}
+
+@Composable
+fun CommentsMenuContent(
+    publicationId: String,
+    commentsViewModel: CommentsViewModel,
+    currentUserId: String,
+    onDismiss: () -> Unit
+) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .background(MaterialTheme.colorScheme.background)
+              .testTag("CommentsMenuContent")) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    "Comments",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.testTag("comments_title"))
+                IconButton(
+                    onClick = onDismiss, modifier = Modifier.testTag("close_comments_button")) {
+                      Icon(Icons.Default.Close, contentDescription = "Close comments")
+                    }
+              }
+          Divider(modifier = Modifier.padding(vertical = 8.dp))
+          CommentSection(publicationId, commentsViewModel, currentUserId)
+        }
+      }
+}
+
+@Composable
+private fun StatItem(
+    label: String,
+    count: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+  Column(
+      modifier = modifier.clickable(onClick = onClick).testTag("stat_${label.lowercase()}"),
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = count.toString(),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.testTag("stat_count_$label"))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag("stat_label_$label"))
+      }
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/search/UserProfileScreen.kt
@@ -7,28 +7,45 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Article
+import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallTopAppBar
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -44,28 +61,38 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.github.se.eduverse.R
+import com.github.se.eduverse.model.MediaType
 import com.github.se.eduverse.model.Publication
+import com.github.se.eduverse.ui.gallery.PublicationItem
 import com.github.se.eduverse.ui.navigation.BottomNavigationMenu
 import com.github.se.eduverse.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.eduverse.ui.navigation.NavigationActions
-import com.github.se.eduverse.ui.profile.PublicationDetailDialog
-import com.github.se.eduverse.ui.profile.PublicationItem
+import com.github.se.eduverse.ui.profile.CommentSection
+import com.github.se.eduverse.ui.profile.CommentsMenuContent
+import com.github.se.eduverse.ui.profile.ExoVideoPlayer
+import com.github.se.eduverse.viewmodel.CommentsViewModel
+import com.github.se.eduverse.viewmodel.DeletePublicationState
 import com.github.se.eduverse.viewmodel.FollowActionState
 import com.github.se.eduverse.viewmodel.ProfileUiState
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.google.firebase.auth.FirebaseAuth
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun UserProfileScreen(
     navigationActions: NavigationActions,
     viewModel: ProfileViewModel,
     userId: String,
+    commentsViewModel: CommentsViewModel,
     currentUserId: String? =
         FirebaseAuth.getInstance().currentUser?.uid // Default for production code
 ) {
@@ -74,194 +101,270 @@ fun UserProfileScreen(
   val likedPublications by viewModel.likedPublications.collectAsState(initial = emptyList())
   val followActionState by viewModel.followActionState.collectAsState()
 
+  var isCommentsVisible by remember { mutableStateOf(false) }
+  var selectedPublicationId by remember { mutableStateOf<String?>(null) }
+
+  val sheetState =
+      rememberModalBottomSheetState(
+          initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+
+  // Show/hide comments sheet when isCommentsVisible changes
+  LaunchedEffect(isCommentsVisible) {
+    if (isCommentsVisible && selectedPublicationId != null) {
+      sheetState.show()
+      commentsViewModel.loadComments(selectedPublicationId!!)
+    } else {
+      sheetState.hide()
+    }
+  }
+
+  // Reset states when sheet is hidden
+  LaunchedEffect(sheetState.currentValue) {
+    if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
+      isCommentsVisible = false
+      selectedPublicationId = null
+    }
+  }
+
   LaunchedEffect(userId) {
     viewModel.loadProfile(userId)
     viewModel.loadLikedPublications(userId)
   }
 
-  Scaffold(
-      modifier = Modifier.testTag("user_profile_screen_container"),
-      topBar = {
-        TopAppBar(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .background(
-                        Brush.horizontalGradient(
-                            colors =
-                                listOf(
-                                    MaterialTheme.colorScheme.secondary,
-                                    MaterialTheme.colorScheme.primary)))
-                    .testTag("user_profile_top_bar"),
-            title = {
-              when (uiState) {
-                is ProfileUiState.Success -> {
-                  Text(
-                      text = (uiState as ProfileUiState.Success).profile.username,
-                      modifier = Modifier.testTag("user_profile_username"),
-                      style = MaterialTheme.typography.titleLarge,
-                      color = MaterialTheme.colorScheme.onPrimary)
-                }
-                else -> {
-                  Text(
-                      "Profile",
-                      modifier = Modifier.testTag("user_profile_title_default"),
-                      style = MaterialTheme.typography.titleLarge,
-                      color = MaterialTheme.colorScheme.onPrimary)
-                }
-              }
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("back_button")) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowBack,
-                        contentDescription = "Back",
-                        tint = MaterialTheme.colorScheme.onPrimary)
-                  }
-            },
-            colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Transparent),
-        )
+  ModalBottomSheetLayout(
+      sheetContent = {
+        if (isCommentsVisible && selectedPublicationId != null) {
+          CommentsMenuContent(
+              publicationId = selectedPublicationId!!,
+              commentsViewModel = commentsViewModel,
+              currentUserId = currentUserId ?: "",
+              onDismiss = {
+                isCommentsVisible = false
+                selectedPublicationId = null
+              })
+        } else {
+          Spacer(modifier = Modifier.height(1.dp))
+        }
       },
-      bottomBar = {
-        BottomNavigationMenu({ navigationActions.navigateTo(it) }, LIST_TOP_LEVEL_DESTINATION, "")
-      }) { paddingValues ->
-        Column(
-            modifier =
-                Modifier.testTag("user_profile_content_container")
-                    .fillMaxSize()
-                    .padding(paddingValues)) {
-              // Profile Image (non-editable)
-              Box(
+      sheetState = sheetState,
+      scrimColor = Color.Black.copy(alpha = 0.32f)) {
+        Scaffold(
+            modifier = Modifier.testTag("user_profile_screen_container"),
+            topBar = {
+              TopAppBar(
                   modifier =
-                      Modifier.testTag("user_profile_image_container")
-                          .fillMaxWidth()
-                          .padding(top = 16.dp),
-                  contentAlignment = Alignment.Center) {
-                    AsyncImage(
-                        model =
-                            if (uiState is ProfileUiState.Success)
-                                (uiState as ProfileUiState.Success).profile.profileImageUrl
-                            else "",
-                        contentDescription = "Profile Image",
-                        modifier = Modifier.size(96.dp).clip(CircleShape),
-                        contentScale = ContentScale.Crop,
-                        placeholder = painterResource(R.drawable.eduverse_logo_alone))
-                  }
-
-              // Stats (Followers/Following)
-              when (uiState) {
-                is ProfileUiState.Success -> {
-                  val profile = (uiState as ProfileUiState.Success).profile
-                  Row(
-                      modifier = Modifier.testTag("stats_row").fillMaxWidth().padding(16.dp),
-                      horizontalArrangement = Arrangement.SpaceEvenly) {
-                        StatItem(
-                            "Followers",
-                            profile.followers,
-                            onClick = { navigationActions.navigateToFollowersList(profile.id) },
-                            Modifier.testTag("followers_stat"))
-                        StatItem(
-                            "Following",
-                            profile.following,
-                            onClick = { navigationActions.navigateToFollowingList(profile.id) },
-                            Modifier.testTag("following_stat"))
+                      Modifier.fillMaxWidth()
+                          .background(
+                              Brush.horizontalGradient(
+                                  colors =
+                                      listOf(
+                                          MaterialTheme.colorScheme.secondary,
+                                          MaterialTheme.colorScheme.primary)))
+                          .testTag("user_profile_top_bar"),
+                  title = {
+                    when (uiState) {
+                      is ProfileUiState.Success -> {
+                        Text(
+                            text = (uiState as ProfileUiState.Success).profile.username,
+                            modifier = Modifier.testTag("user_profile_username"),
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onPrimary)
                       }
+                      else -> {
+                        Text(
+                            "Profile",
+                            modifier = Modifier.testTag("user_profile_title_default"),
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onPrimary)
+                      }
+                    }
+                  },
+                  navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("back_button")) {
+                          Icon(
+                              imageVector = Icons.Default.ArrowBack,
+                              contentDescription = "Back",
+                              tint = MaterialTheme.colorScheme.onPrimary)
+                        }
+                  },
+                  colors =
+                      TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Transparent),
+              )
+            },
+            bottomBar = {
+              BottomNavigationMenu(
+                  onTabSelect = { navigationActions.navigateTo(it) },
+                  tabList = LIST_TOP_LEVEL_DESTINATION,
+                  selectedItem = "")
+            }) { paddingValues ->
+              Column(
+                  modifier =
+                      Modifier.testTag("user_profile_content_container")
+                          .fillMaxSize()
+                          .padding(paddingValues)) {
+                    Spacer(modifier = Modifier.height(12.dp))
 
-                  // Follow/Unfollow Button
-                  if (currentUserId != null && currentUserId != userId) {
-                    Button(
-                        onClick = { viewModel.toggleFollow(currentUserId, userId) },
+                    // Profile Image
+                    Box(
                         modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .testTag("follow_button"),
-                        enabled = followActionState != FollowActionState.Loading) {
-                          when (followActionState) {
-                            FollowActionState.Loading -> {
-                              CircularProgressIndicator(
-                                  modifier = Modifier.size(24.dp),
-                                  color = MaterialTheme.colorScheme.onTertiary)
-                            }
-                            else -> {
-                              when (uiState) {
-                                is ProfileUiState.Success -> {
-                                  val profile = (uiState as ProfileUiState.Success).profile
-                                  Text(
-                                      if (profile.isFollowedByCurrentUser) "Unfollow" else "Follow")
-                                }
-                                else -> Text("Follow")
-                              }
-                            }
-                          }
+                            Modifier.testTag("user_profile_image_container")
+                                .fillMaxWidth()
+                                .padding(top = 16.dp),
+                        contentAlignment = Alignment.Center) {
+                          val profileUrl =
+                              if (uiState is ProfileUiState.Success)
+                                  (uiState as ProfileUiState.Success).profile.profileImageUrl
+                              else ""
+
+                          AsyncImage(
+                              model = profileUrl,
+                              contentDescription = "Profile Image",
+                              modifier = Modifier.size(96.dp).clip(CircleShape),
+                              contentScale = ContentScale.Crop,
+                              placeholder = painterResource(R.drawable.eduverse_logo_alone))
                         }
 
-                    // Show error if follow action failed
-                    if (followActionState is FollowActionState.Error) {
-                      Text(
-                          text = (followActionState as FollowActionState.Error).message,
-                          color = MaterialTheme.colorScheme.error,
-                          style = MaterialTheme.typography.bodySmall,
-                          modifier = Modifier.padding(horizontal = 16.dp))
+                    // Stats & Follow Button
+                    when (uiState) {
+                      is ProfileUiState.Success -> {
+                        val profile = (uiState as ProfileUiState.Success).profile
+                        Row(
+                            modifier = Modifier.testTag("stats_row").fillMaxWidth().padding(16.dp),
+                            horizontalArrangement = Arrangement.SpaceEvenly) {
+                              StatItem(
+                                  "Followers",
+                                  profile.followers,
+                                  onClick = {
+                                    navigationActions.navigateToFollowersList(profile.id)
+                                  },
+                                  Modifier.testTag("followers_stat"))
+                              StatItem(
+                                  "Following",
+                                  profile.following,
+                                  onClick = {
+                                    navigationActions.navigateToFollowingList(profile.id)
+                                  },
+                                  Modifier.testTag("following_stat"))
+                            }
+
+                        if (currentUserId != null && currentUserId != userId) {
+                          val followActionStateValue = followActionState
+                          Button(
+                              onClick = { viewModel.toggleFollow(currentUserId, userId) },
+                              modifier =
+                                  Modifier.fillMaxWidth()
+                                      .padding(horizontal = 16.dp)
+                                      .testTag("follow_button"),
+                              enabled = followActionStateValue != FollowActionState.Loading) {
+                                when (followActionStateValue) {
+                                  FollowActionState.Loading -> {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(24.dp),
+                                        color = MaterialTheme.colorScheme.onTertiary)
+                                  }
+                                  else -> {
+                                    val profile = (uiState as ProfileUiState.Success).profile
+                                    Text(
+                                        if (profile.isFollowedByCurrentUser) "Unfollow"
+                                        else "Follow")
+                                  }
+                                }
+                              }
+
+                          if (followActionStateValue is FollowActionState.Error) {
+                            Text(
+                                text = followActionStateValue.message,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(horizontal = 16.dp))
+                          }
+                        }
+                      }
+                      else -> {}
+                    }
+
+                    // Tabs (Publications/Favorites)
+                    TabRow(
+                        selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
+                          Tab(
+                              selected = selectedTab == 0,
+                              onClick = { selectedTab = 0 },
+                              modifier = Modifier.testTag("publications_tab"),
+                              text = { Text("Publications") },
+                              icon = { Icon(Icons.Default.Article, contentDescription = null) },
+                              selectedContentColor =
+                                  if (selectedTab == 0) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                          Tab(
+                              selected = selectedTab == 1,
+                              onClick = { selectedTab = 1 },
+                              modifier = Modifier.testTag("favorites_tab"),
+                              text = { Text("Favorites") },
+                              icon = { Icon(Icons.Default.Favorite, contentDescription = null) },
+                              selectedContentColor =
+                                  if (selectedTab == 1) MaterialTheme.colorScheme.primary
+                                  else MaterialTheme.colorScheme.onSurface)
+                        }
+
+                    // Content
+                    when (uiState) {
+                      is ProfileUiState.Loading -> {
+                        Box(
+                            modifier = Modifier.testTag("loading_container").fillMaxSize(),
+                            contentAlignment = Alignment.Center) {
+                              CircularProgressIndicator(
+                                  modifier = Modifier.testTag("loading_indicator"))
+                            }
+                      }
+                      is ProfileUiState.Error -> {
+                        ErrorMessage(
+                            message = (uiState as ProfileUiState.Error).message,
+                            modifier = Modifier.testTag("error_container"))
+                      }
+                      is ProfileUiState.Success -> {
+                        val profile = (uiState as ProfileUiState.Success).profile
+                        val publications =
+                            if (selectedTab == 0) {
+                              profile.publications
+                            } else {
+                              likedPublications
+                            }
+
+                        var localSelectedPublication by remember {
+                          mutableStateOf<Publication?>(null)
+                        }
+
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(3),
+                            modifier = Modifier.testTag("publications_grid").fillMaxSize(),
+                            contentPadding = PaddingValues(1.dp),
+                            horizontalArrangement = Arrangement.spacedBy(1.dp),
+                            verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                              items(publications) { publication ->
+                                PublicationItem(
+                                    mediaType = publication.mediaType,
+                                    thumbnailUrl = publication.thumbnailUrl,
+                                    onClick = { localSelectedPublication = publication },
+                                    modifier =
+                                        Modifier.testTag("publication_item_${publication.id}"))
+                              }
+                            }
+
+                        // If a publication is selected, show detail dialog with comment features
+                        localSelectedPublication?.let { pub ->
+                          PublicationDetailDialog(
+                              publication = pub,
+                              profileViewModel = viewModel,
+                              currentUserId = currentUserId ?: "",
+                              commentsViewModel = commentsViewModel,
+                              onDismiss = { localSelectedPublication = null },
+                          )
+                        }
+                      }
                     }
                   }
-                }
-                else -> {}
-              }
-
-              // Publications/Favorites Tabs
-              TabRow(selectedTabIndex = selectedTab, modifier = Modifier.testTag("tabs_row")) {
-                Tab(
-                    selected = selectedTab == 0,
-                    onClick = { selectedTab = 0 },
-                    modifier = Modifier.testTag("publications_tab"),
-                    text = { Text("Publications") },
-                    icon = { Icon(Icons.Default.Article, contentDescription = null) },
-                    selectedContentColor =
-                        if (selectedTab == 0) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurface)
-                Tab(
-                    selected = selectedTab == 1,
-                    onClick = { selectedTab = 1 },
-                    modifier = Modifier.testTag("favorites_tab"),
-                    text = { Text("Favorites") },
-                    icon = { Icon(Icons.Default.Favorite, contentDescription = null) },
-                    selectedContentColor =
-                        if (selectedTab == 1) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurface)
-              }
-
-              // Content based on state
-              when (uiState) {
-                is ProfileUiState.Loading -> {
-                  Box(
-                      modifier = Modifier.testTag("loading_container").fillMaxSize(),
-                      contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(modifier = Modifier.testTag("loading_indicator"))
-                      }
-                }
-                is ProfileUiState.Error -> {
-                  ErrorMessage(
-                      message = (uiState as ProfileUiState.Error).message,
-                      modifier = Modifier.testTag("error_container"))
-                }
-                is ProfileUiState.Success -> {
-                  val profile = (uiState as ProfileUiState.Success).profile
-                  val publications =
-                      if (selectedTab == 0) {
-                        profile.publications
-                      } else {
-                        likedPublications
-                      }
-
-                  PublicationsGrid(
-                      publications = publications,
-                      currentUserId = currentUserId ?: "",
-                      profileViewModel = viewModel,
-                      onPublicationClick = { /* Handle publication click */},
-                      modifier = Modifier.testTag("publications_grid"))
-                }
-              }
             }
       }
 }
@@ -299,48 +402,243 @@ private fun StatItem(
       }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun PublicationsGrid(
-    publications: List<Publication>,
-    currentUserId: String,
+fun PublicationDetailDialog(
+    publication: Publication,
     profileViewModel: ProfileViewModel,
-    onPublicationClick: (Publication) -> Unit,
-    modifier: Modifier = Modifier
+    commentsViewModel: CommentsViewModel,
+    currentUserId: String,
+    onDismiss: () -> Unit
 ) {
-  var selectedPublication by remember { mutableStateOf<Publication?>(null) }
+  val isLiked = remember { mutableStateOf(publication.likedBy.contains(currentUserId)) }
+  val likeCount = remember { mutableStateOf(publication.likes) }
+  var showDeleteDialog by remember { mutableStateOf(false) }
+  val deleteState by profileViewModel.deletePublicationState.collectAsState()
 
-  if (publications.isEmpty()) {
-    Box(
-        modifier = Modifier.testTag("empty_publications_container").fillMaxSize(),
-        contentAlignment = Alignment.Center) {
-          Text(
-              text = "No publications yet",
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-              modifier = Modifier.testTag("empty_publications_text"))
-        }
-  } else {
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(1.dp),
-        horizontalArrangement = Arrangement.spacedBy(1.dp),
-        verticalArrangement = Arrangement.spacedBy(1.dp)) {
-          items(publications) { publication ->
-            PublicationItem(
-                publication = publication,
-                onClick = { selectedPublication = publication },
-                modifier = Modifier.testTag("publication_item_${publication.id}"))
-          }
-        }
+  var isFavorited by remember { mutableStateOf(false) }
+  LaunchedEffect(publication.id) {
+    isFavorited = profileViewModel.repository.isPublicationFavorited(currentUserId, publication.id)
+  }
 
-    // Show detail dialog when a publication is selected
-    selectedPublication?.let { publication ->
-      PublicationDetailDialog(
-          publication = publication,
-          profileViewModel = profileViewModel,
-          currentUserId = currentUserId,
-          onDismiss = { selectedPublication = null })
+  var errorMessage by remember { mutableStateOf<String?>(null) }
+
+  // State to show comments like a bottom sheet overlay in the dialog
+  var showComments by remember { mutableStateOf(false) }
+
+  LaunchedEffect(showComments) {
+    if (showComments) {
+      commentsViewModel.loadComments(publication.id)
     }
   }
+
+  LaunchedEffect(deleteState) {
+    when (deleteState) {
+      is DeletePublicationState.Success -> {
+        errorMessage = null
+        onDismiss()
+        profileViewModel.resetDeleteState()
+      }
+      is DeletePublicationState.Error -> {
+        errorMessage = (deleteState as DeletePublicationState.Error).message
+        profileViewModel.resetDeleteState()
+      }
+      else -> {
+        errorMessage = null
+      }
+    }
+  }
+
+  // Confirmation dialog for delete action
+  if (showDeleteDialog) {
+    AlertDialog(
+        onDismissRequest = { showDeleteDialog = false },
+        title = { Text("Delete Publication") },
+        text = {
+          Text("Are you sure you want to delete this publication? This action cannot be undone.")
+        },
+        confirmButton = {
+          Button(
+              onClick = {
+                profileViewModel.deletePublication(publication.id, currentUserId)
+                showDeleteDialog = false
+              },
+              colors =
+                  ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)) {
+                Text("Delete")
+              }
+        },
+        dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") } })
+  }
+
+  Dialog(
+      onDismissRequest = onDismiss,
+      properties =
+          DialogProperties(
+              usePlatformDefaultWidth = false,
+              dismissOnBackPress = true,
+              dismissOnClickOutside = false)) {
+        Box(modifier = Modifier.fillMaxSize().testTag("publication_detail_dialog")) {
+          Column(modifier = Modifier.fillMaxSize()) {
+            Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
+              Column(modifier = Modifier.fillMaxSize()) {
+                SmallTopAppBar(
+                    title = {
+                      Text(
+                          publication.title,
+                          color = Color.White,
+                          modifier = Modifier.testTag("publication_title"))
+                    },
+                    navigationIcon = {
+                      IconButton(onClick = onDismiss, modifier = Modifier.testTag("close_button")) {
+                        Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                      }
+                    },
+                    actions = {
+                      if (publication.userId == currentUserId) {
+                        IconButton(
+                            onClick = { showDeleteDialog = true },
+                            modifier = Modifier.testTag("delete_button")) {
+                              Icon(
+                                  imageVector = Icons.Default.Delete,
+                                  contentDescription = "Delete publication",
+                                  tint = Color.White)
+                            }
+                      }
+                    },
+                    colors =
+                        TopAppBarDefaults.smallTopAppBarColors(
+                            containerColor = Color.Black, titleContentColor = Color.White))
+
+                Box(
+                    modifier = Modifier.weight(1f).fillMaxWidth().testTag("media_container"),
+                    contentAlignment = Alignment.Center) {
+                      when (publication.mediaType) {
+                        MediaType.VIDEO -> {
+                          ExoVideoPlayer(
+                              videoUrl = publication.mediaUrl,
+                              modifier = Modifier.fillMaxWidth().testTag("video_player"))
+                        }
+                        MediaType.PHOTO -> {
+                          AsyncImage(
+                              model =
+                                  ImageRequest.Builder(LocalContext.current)
+                                      .data(publication.mediaUrl)
+                                      .crossfade(true)
+                                      .build(),
+                              contentDescription = "Publication media",
+                              modifier = Modifier.fillMaxSize().testTag("detail_photo_view"),
+                              contentScale = ContentScale.Fit)
+                        }
+                      }
+
+                      // Action Buttons Column (Like, Comment, Favorite)
+                      Column(
+                          modifier =
+                              Modifier.align(Alignment.CenterEnd)
+                                  .padding(16.dp)
+                                  .testTag("action_buttons"),
+                          horizontalAlignment = Alignment.CenterHorizontally,
+                          verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                            // Like Button
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                              IconButton(
+                                  onClick = {
+                                    if (isLiked.value) {
+                                      profileViewModel.removeLike(currentUserId, publication.id)
+                                      isLiked.value = false
+                                      likeCount.value -= 1
+                                    } else {
+                                      profileViewModel.likeAndAddToFavorites(
+                                          currentUserId, publication.id)
+                                      isLiked.value = true
+                                      likeCount.value += 1
+                                    }
+                                  },
+                                  modifier = Modifier.testTag("like_button")) {
+                                    Icon(
+                                        imageVector = Icons.Default.Favorite,
+                                        contentDescription = "Like",
+                                        tint = if (isLiked.value) Color.Red else Color.White,
+                                        modifier = Modifier.size(48.dp))
+                                  }
+                              Text(
+                                  text = likeCount.value.toString(),
+                                  style = MaterialTheme.typography.bodyMedium,
+                                  color = Color.White,
+                                  modifier = Modifier.testTag("like_count_${publication.id}"))
+                            }
+
+                            // Comment Button - show comments in a style similar to ProfileScreen
+                            IconButton(
+                                onClick = { showComments = true },
+                                modifier = Modifier.testTag("comment_button")) {
+                                  Icon(
+                                      painter = painterResource(id = R.drawable.comment),
+                                      contentDescription = "Comment",
+                                      tint = Color.White,
+                                      modifier = Modifier.size(48.dp))
+                                }
+
+                            // Favorite Button
+                            IconButton(
+                                onClick = {
+                                  profileViewModel.toggleFavorite(currentUserId, publication.id)
+                                  isFavorited = !isFavorited
+                                },
+                                modifier = Modifier.testTag("favorite_button")) {
+                                  Icon(
+                                      imageVector = Icons.Default.BookmarkAdd,
+                                      contentDescription = "Favorite",
+                                      tint = if (isFavorited) Color.Yellow else Color.White,
+                                      modifier = Modifier.size(48.dp))
+                                }
+                          }
+
+                      // If we are showing comments, replicate the bottom sheet style here
+                      if (showComments) {
+                        // Overlay a surface that looks like CommentsMenuContent
+                        Box(
+                            modifier =
+                                Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)),
+                            contentAlignment = Alignment.BottomCenter) {
+                              Surface(
+                                  modifier =
+                                      Modifier.fillMaxWidth()
+                                          .heightIn(min = 200.dp)
+                                          .clip(
+                                              RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                                          .background(MaterialTheme.colorScheme.background),
+                                  color = MaterialTheme.colorScheme.background) {
+                                    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                                      Row(
+                                          modifier = Modifier.fillMaxWidth(),
+                                          horizontalArrangement = Arrangement.SpaceBetween,
+                                          verticalAlignment = Alignment.CenterVertically) {
+                                            Text(
+                                                "Comments",
+                                                style = MaterialTheme.typography.titleLarge,
+                                                modifier = Modifier.testTag("comments_title"))
+                                            IconButton(
+                                                onClick = { showComments = false },
+                                                modifier =
+                                                    Modifier.testTag("close_comments_button")) {
+                                                  Icon(
+                                                      Icons.Default.Close,
+                                                      contentDescription = "Close comments")
+                                                }
+                                          }
+                                      Divider(modifier = Modifier.padding(vertical = 8.dp))
+                                      CommentSection(
+                                          publication.id, commentsViewModel, currentUserId)
+                                    }
+                                  }
+                            }
+                      }
+                    }
+              }
+            }
+          }
+        }
+      }
 }

--- a/app/src/main/java/com/github/se/eduverse/ui/setting/SavedScreen.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/setting/SavedScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.eduverse.R
+import com.github.se.eduverse.ui.gallery.PublicationItem
 import com.github.se.eduverse.ui.navigation.NavigationActions
 import com.github.se.eduverse.ui.navigation.TopNavigationBar
-import com.github.se.eduverse.ui.profile.PublicationDetailDialog
-import com.github.se.eduverse.ui.profile.PublicationItem
+import com.github.se.eduverse.ui.profile.PublicationDetailView
 import com.github.se.eduverse.viewmodel.ProfileViewModel
 import com.google.firebase.auth.FirebaseAuth
 
@@ -57,7 +57,8 @@ fun SavedScreen(
               verticalArrangement = Arrangement.spacedBy(1.dp)) {
                 items(favoritePublications) { publication ->
                   PublicationItem(
-                      publication = publication,
+                      publication.mediaType,
+                      publication.thumbnailUrl,
                       onClick = { selectedPublication = publication },
                       modifier = Modifier.testTag("saved_publication_${publication.id}"))
                 }
@@ -65,11 +66,12 @@ fun SavedScreen(
 
           // Show detail dialog when a publication is selected
           selectedPublication?.let { publication ->
-            PublicationDetailDialog(
+            PublicationDetailView(
                 publication = publication,
                 profileViewModel = viewModel,
                 currentUserId = userId,
-                onDismiss = { selectedPublication = null })
+                onDismiss = { selectedPublication = null },
+                onShowComments = {})
           }
         }
       }


### PR DESCRIPTION
## :memo: Description

This pull request introduces significant enhancements to the user profile and publication detail views, adapts existing components, and updates test cases to align with the new functionality. However, this pull request is not ready for merging as the task is incomplete and additional time is needed to finalize and perfect the changes. Below is a detailed summary of the modifications made so far:

## :gear:  MainActivity Modifications

Updated the MainActivity to pass the CommentsViewModel along with navigationActions, ProfileViewModel, and userId when navigating to the profile screens:
navigationActions = navigationActions,
viewModel = profileViewModel,
commentsViewModel = CommentsViewModel,
userId = userId
## :bust_in_silhouette: Profile Screen Updates

Added the ability to view, like, and delete comments on publications directly from the profile screen.
Incorporated the CommentsViewModel to handle comment-related operations.
Utilized a bottom sheet for displaying comments, ensuring consistency with the existing VideoScreen components.
Enhanced publication interaction capabilities, supporting both photos and videos:
Like and unlike publications.
View the comment section for each publication.
Delete comments when authorized.
## :floppy_disk: Saved Screen Changes

Replaced the PublicationDetailDialog component with the new PublicationDetailView to support comment functionality:
PublicationDetailView(
    publication = publication,
    profileViewModel = viewModel,
    currentUserId = userId,
    onDismiss = { selectedPublication = null },
    onShowComments = {}
)
## :busts_in_silhouette: User Profile Screen Updates

Mirrored the comment functionality from the profile screen, allowing users to interact with comments directly within the user profile screen.
Included the ability to like, delete, and view comments on publications in the user profile.
:test_tube: Test Updates

## :white_check_mark: Profile Screen Test
Added new test cases to cover the following scenarios:
Viewing comments on a publication.
Liking and unliking a publication with comments.
Deleting comments as the owner.
Ensuring that comment-related UI elements appear and function correctly.
:white_check_mark: User Profile Screen Test
Wrote new tests to validate the added comment functionality in the user profile screen.
Ensured test cases verify:
Comment sheet interaction (open, close, add, like, delete).
Proper rendering of publication items with comment buttons.
:white_check_mark: SocialInteractionE2ETest
Adapted the existing end-to-end test cases to accommodate the updated user profile screen, which now requires the CommentsViewModel to function correctly.
:warning: Known Issues and Next Steps

##This pull request is not for merge as the task remains incomplete:

Some features require refinement and additional testing.
Certain UI and backend interactions may need adjustments to improve user experience and stability.
Time constraints prevented the task from being fully completed.
:camera: Screenshots

![image](https://github.com/user-attachments/assets/0ff37f48-917e-40b0-b788-7c94e6c0c59f)
![image](https://github.com/user-attachments/assets/f2fbd50d-0a5b-4288-af6e-7a55f794f536)
![image](https://github.com/user-attachments/assets/28de8495-06b4-43c3-8f81-3c56a6d69eb1)

## :rocket: Conclusion

This pull request lays the groundwork for a robust comment functionality in the user and profile screens, while maintaining compatibility with existing publication logic. Further work is required to finalize the implementation and ensure the feature is production-ready. THIS PR SHOULDN'T BE MERGED AS THE TESTS WEREN'T ADAPTED PERFECTLY