### PR TITLE
Fix/remove french from suggested app languages

### DIFF
--- a/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/eduverse/ui/setting/SettingsScreenTest.kt
@@ -172,20 +172,20 @@ class SettingsScreenTest {
   /** Test to verify that the language dropdown displays the correct current selection. */
   @Test
   fun languageDropdown_displaysCurrentSelection() {
-    // Arrange: Set the language to "Français"
-    fakeViewModel.setSelectedLanguage("Français")
+    // Arrange: Set the language to "English"
+    fakeViewModel.setSelectedLanguage("English")
 
     // Act: Set the content
     composeTestRule.setContent {
       SettingsScreen(navigationActions = fakeNavigationActions, settingsViewModel = fakeViewModel)
     }
 
-    // Assert: The language dropdown displays "Français"
+    // Assert: The language dropdown displays "English"
     composeTestRule
         .onNodeWithTag("languageDropdown")
         .assert(
             SemanticsMatcher.expectValue(
-                SemanticsProperties.Text, listOf(AnnotatedString("Language: Français"))))
+                SemanticsProperties.Text, listOf(AnnotatedString("Language: English"))))
   }
 
   /** Test to verify that the settings options are displayed correctly and navigable. */

--- a/app/src/main/java/com/github/se/eduverse/ui/setting/Setting.kt
+++ b/app/src/main/java/com/github/se/eduverse/ui/setting/Setting.kt
@@ -162,7 +162,7 @@ fun SettingsScreen(
                     SettingsDropdown(
                         label = "Language",
                         selectedOption = selectedLanguage,
-                        options = listOf("Français", "English"),
+                        options = listOf("English"),
                         onOptionSelected = { settingsViewModel.updateSelectedLanguage(it) },
                         isExpanded = isLanguageDropdownExpanded,
                         onExpandChange = { isLanguageDropdownExpanded = it },


### PR DESCRIPTION
This PR removes french from the suggested app languages in the settings, since the switch between languages is not implemented in the app.